### PR TITLE
fix(docs): correct a couple links in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Getting Started
 
-Everything to know about the components, props, and usage is available within our [Documentation Site](https://jsx.email/docs). Please give that a read and let us know if there's anything we can help with.
+Everything to know about the components, props, and usage is available within our [Documentation Site](https://jsx.email/docs/introduction). Please give that a read and let us know if there's anything we can help with.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This includes [AWS SES](https://aws.amazon.com/ses), [Loops](https://loops.so), 
 
 We 💛 contributions! After all, this is a community-driven project. We have no corporate sponsorship or backing. The maintainers and users keep this project going!
 
-Please check out our [Contribution Guide](./contributing.md).
+Please check out our [Contribution Guide](./CONTRIBUTING.md).
 
 ## Attribution 🧡
 


### PR DESCRIPTION
## Component / Package Name: README.md

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [X] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no


List any relevant issue numbers:

N/A

### Description

The link to the docs site (https://jsx.email/docs/) 404s and the contributing guide link had a different casing which also 404'd.