### PR TITLE
fix(cli): mustache template path, character escaping

### DIFF
--- a/packages/cli/src/assets/email.mustache
+++ b/packages/cli/src/assets/email.mustache
@@ -24,7 +24,7 @@ export const TemplateStruct = object({
   email: defaulted(string(), 'batman@example.com'),
   name: defaulted(string(), 'Bruce Wayne')
 });
-{{ typeProps }}
+{{{ typeProps }}}
 
 const main = {
   backgroundColor: '#f6f9fc',

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -40,7 +40,7 @@ export const command: CommandFn = async (argv: CreateOptions, input) => {
 
   const [name] = input;
   const { jsx, out } = argv;
-  const template = await readFile(join(__dirname, '../assets/email.tsx.mustache'), 'utf8');
+  const template = await readFile(join(__dirname, '../assets/email.mustache'), 'utf8');
   const data = {
     name,
     propsType: jsx ? '' : ': TemplateProps',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:
Cli
This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
- Fix the moustache template path `email.tsx.moustache` to `email.moustache`
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
