### PR TITLE
fix(cli): use vite builtins for perf improvement in preview

### DIFF
--- a/packages/cli/app/src/main.tsx
+++ b/packages/cli/app/src/main.tsx
@@ -30,29 +30,23 @@ const parseName = (path: string) => {
 };
 
 // @ts-ignore
+const sources = sǝɔɹnoslᴉɐɯǝxsɾ;
+
+// Note: ./@templates/ is a symlink to the targetPath within local app/src/
+// @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const modules = import.meta.glob('./@templates/*.tsx');
-
-// TODO: use `modules` to populate the data below. it's more reliable
-
-const targetPath = JSON.parse(process.env.VITE_TARGET_PATH!) as string;
-const templatePaths = JSON.parse(import.meta.env.VITE_EMAIL_COMPONENTS) as string[];
-console.log({ targetPath, templatePaths });
+const imports = import.meta.glob('./@templates/*.tsx');
 const templates = await Promise.all(
-  templatePaths.map<Promise<TemplateData>>(async (path) => {
-    const fileName = path.replace(targetPath, '');
-    const bareFileName = fileName.substring(1, fileName.lastIndexOf('.'));
-    const template = (await import(`./@templates/${bareFileName}.tsx`)) as TemplateExports;
-    const response = await fetch(fileName);
-    const source = await response.text();
+  Object.entries(imports).map<Promise<TemplateData>>(async ([path, fn]) => {
+    const bareFileName = path.replace('./@templates/', '');
+    const component = (await fn()) as TemplateExports;
     const result: TemplateData = {
-      jsx: source,
-      Name: template.Name || parseName(path),
-      PreviewProps: template.PreviewProps,
-      Struct: template.Struct,
-      Template: template.Template || (template as any).default
+      jsx: sources[bareFileName],
+      Name: component.Name || parseName(path),
+      PreviewProps: component.PreviewProps,
+      Struct: component.Struct,
+      Template: component.Template || (component as any).default
     };
-
     return result;
   })
 );


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This improves performance of load time for the preview tool in the CLI by using some vite builtins (which were discovered as the fix to preview issues outside of the repo in a prior PR). Also injects the source code of the target templates into the bundle before bundling, thus avoiding a costly `fetch` in client-side code.

Still need someone with a keen React eye to help improve rendering on these pages, since there are some obvious refreshes, but that can come later.