### PR TITLE
fix(cli): use react-router-dom `Link` component in preview

### DIFF
--- a/packages/cli/app/src/components/sidebar.tsx
+++ b/packages/cli/app/src/components/sidebar.tsx
@@ -2,6 +2,7 @@ import * as Collapsible from '@radix-ui/react-collapsible';
 import classnames from 'classnames';
 import { LayoutGroup, motion } from 'framer-motion';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 
 import { Heading } from './heading';
 import { Logo } from './logo';
@@ -82,7 +83,7 @@ export const Sidebar = React.forwardRef<SidebarElement, Readonly<SidebarProps>>(
                     templateNames.map((item) => {
                       const isCurrentPage = title === item;
                       return (
-                        <a key={item} href={`/${item}`}>
+                        <Link key={item} href={`/${item}`}>
                           <motion.span
                             className={classnames(
                               'text-[14px] flex items-center gap-2 w-full pl-4 h-8 rounded-md relative transition ease-in-out duration-200',
@@ -131,7 +132,7 @@ export const Sidebar = React.forwardRef<SidebarElement, Readonly<SidebarProps>>(
                             </svg>
                             {item}
                           </motion.span>
-                        </a>
+                        </Link>
                       );
                     })}
                 </LayoutGroup>


### PR DESCRIPTION
## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

### Description

Previously, the Preview app from the CLI had an issue with seeing FOUC or a white screen when navigating between email templates. This occurred because the project uses `react-router-dom`, but was **_not_** using its `Link` component to navigate.

This caused the entire unmount/mount of the React tree when clicking a link to another template (because it was fetching a completely new page).
