### PR TITLE
fix(cli): Normalize globby path for cli build command

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, realpath, writeFile } from 'node:fs/promises';
 import os from 'node:os';
-import { basename, extname, join, resolve } from 'path';
+import { basename, extname, join, resolve, win32, posix } from 'path';
 
 import { render } from '@jsx-email/render';
 import chalk from 'chalk';
@@ -61,6 +61,9 @@ const pretty = (html: string) => {
   return beautify.html(html, defaults);
 };
 
+// Credit: https://github.com/rollup/plugins/blob/master/packages/pluginutils/src/normalizePath.ts#L5
+const normalizePath = (filename: string) => filename.split(win32.sep).join(posix.sep);
+
 const stripHtml = (html: string) => {
   const $ = load(html);
 
@@ -108,7 +111,7 @@ const compile = async (files: string[], outDir: string) => {
     write: true
   });
 
-  return globby([join(outDir, '*.js')]);
+  return globby([normalizePath(join(outDir, '*.js'))]);
 };
 
 export const command: CommandFn = async (argv: BuildOptions, input) => {
@@ -129,7 +132,7 @@ export const command: CommandFn = async (argv: BuildOptions, input) => {
   const isFile = target.endsWith('.tsx') || target.endsWith('.jsx');
   const { out = '.rendered' } = argv;
   const glob = isFile ? target : join(target, '*.{jsx,tsx}');
-  const targetFiles = await globby([glob]);
+  const targetFiles = await globby([normalizePath(glob)]);
   const outputPath = resolve(out);
 
   log('Found', targetFiles.length, 'files:');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

I used the existing test suite and did not make any new tests

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->
resolves #41 

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

As discussed in #41, the jsx-email's CLI `build` command use `globby` to search for file names to read, build, and write to. However, per https://github.com/sindresorhus/globby/issues/179, on Windows system, Globby won't work as Windows path contains backslashes but Globby only wants path with forward slashes.
Therefore, a `normalizePath` function (inspired by [rollup](https://github.com/rollup/plugins/blob/master/packages/pluginutils/src/normalizePath.ts#L5)) was used to normalize the path so it would work on both Windows and UNIX systems
