### PR TITLE
fix(cli): add spaces for camel case template names in preview

### DIFF
--- a/packages/cli/app/src/main.tsx
+++ b/packages/cli/app/src/main.tsx
@@ -21,12 +21,14 @@ interface TemplateData extends TemplateExports {
   jsx: string;
 }
 
+const addSpacesForCamelCaseName = (str: string) => str.replace(/([a-z])([A-Z])/g, '$1 $2');
+
 const parseName = (path: string) => {
   const chunks = path.replace('\\', '/').split('/');
   const segment = chunks.at(-1);
   const basename = segment!.split(/\.[^.]+$/)[0];
 
-  return titleize(basename);
+  return titleize(addSpacesForCamelCaseName(basename));
 };
 
 const modules = import.meta.glob('@/*.tsx', { eager: true });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Currently in the preview sidebar the template names are displayed as one string with only the first letter uppercase. This does not work well for camelCase names, since you can't distinguish the words anymore. E.g.: NewCustomerWithNewAccount -> Newcustomerwithnewaccount which is hard to read.
With this fix it will display as: "New Customer With New Account".