### PR TITLE
fix(tailwind): responsive classname error

### DIFF
--- a/packages/tailwind/src/tailwind.tsx
+++ b/packages/tailwind/src/tailwind.tsx
@@ -28,7 +28,8 @@ function processElement(
         convertedStyles.push(tailwindClassNames);
         return false;
       } else if (twi(className, { ignoreMediaQueries: false })) {
-        responsiveStyles.push(className);
+        const [breakpoint, twClass] = className.split(':');
+        responsiveStyles.push(twClass.startsWith('!') ? className : `${breakpoint}:!${twClass}`);
         return false;
       }
       return true;
@@ -41,11 +42,13 @@ function processElement(
 
     headStyles.push(convertedResponsiveStyles.replace(/^\n+/, '').replace(/\n+$/, ''));
 
+    const finalClassNames = [...customClassNames, ...responsiveStyles];
+
     // eslint-disable-next-line no-param-reassign
     element = React.cloneElement(element, {
       ...element.props,
       // eslint-disable-next-line no-undefined
-      className: customClassNames.length ? customClassNames.join(' ') : undefined,
+      className: finalClassNames.length ? finalClassNames.join(' ') : undefined,
       style: { ...element.props.style, ...cssToJsxStyle(convertedStyles.join(' ')) }
     });
   }

--- a/packages/tailwind/test/.snapshots/tailwind.test.tsx.snap
+++ b/packages/tailwind/test/.snapshots/tailwind.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Custom plugins config > should be able to use custom plugins 1`] = `"<div style=\\"border:2px solid\\"></div>"`;
 
-exports[`Custom plugins config > should be able to use custom plugins with responsive styles 1`] = `"<html><head><style>@media(min-width:640px){.sm\\\\:border-custom{border:2px solid}}</style></head><body><div style=\\"border:2px solid\\"></div></body></html>"`;
+exports[`Custom plugins config > should be able to use custom plugins with responsive styles 1`] = `"<html><head><style>@media(min-width:640px){.sm\\\\:\\\\!border-custom{border:2px solid !important}}</style></head><body><div class=\\"sm:!border-custom\\" style=\\"border:2px solid\\"></div></body></html>"`;
 
 exports[`Custom theme config > should be able to use custom border radius 1`] = `"<div style=\\"border-radius:2rem\\"></div>"`;
 
@@ -14,9 +14,9 @@ exports[`Custom theme config > should be able to use custom spacing 1`] = `"<div
 
 exports[`Custom theme config > should be able to use custom text alignment 1`] = `"<div style=\\"text-align:justify\\"></div>"`;
 
-exports[`Responsive styles > should add css to <head/> 1`] = `"<html><head><style>@media(min-width:640px){.sm\\\\:bg-red-300{background-color:rgb(252,165,165)}}@media(min-width:768px){.md\\\\:bg-red-400{background-color:rgb(248,113,113)}}@media(min-width:1024px){.lg\\\\:bg-red-500{background-color:rgb(239,68,68)}}</style></head><body><div style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"`;
+exports[`Responsive styles > should add css to <head/> 1`] = `"<html><head><style>@media(min-width:640px){.sm\\\\:\\\\!bg-red-300{background-color:rgb(252,165,165) !important}}@media(min-width:768px){.md\\\\:\\\\!bg-red-400{background-color:rgb(248,113,113) !important}}@media(min-width:1024px){.lg\\\\:\\\\!bg-red-500{background-color:rgb(239,68,68) !important}}</style></head><body><div class=\\"sm:!bg-red-300 md:!bg-red-400 lg:!bg-red-500\\" style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"`;
 
-exports[`Responsive styles > should persist exsisting <head/> elements 1`] = `"<html><head><style></style><link/><style>@media(min-width:640px){.sm\\\\:bg-red-500{background-color:rgb(239,68,68)}}</style></head><body><div style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"`;
+exports[`Responsive styles > should persist exsisting <head/> elements 1`] = `"<html><head><style></style><link/><style>@media(min-width:640px){.sm\\\\:\\\\!bg-red-500{background-color:rgb(239,68,68) !important}}</style></head><body><div class=\\"sm:!bg-red-500\\" style=\\"background-color:rgb(254,202,202)\\"></div></body></html>"`;
 
 exports[`Tailwind component > should be able to use background image 1`] = `"<div style=\\"background-image:url(https://example.com/image.png)\\"></div>"`;
 

--- a/packages/tailwind/test/tailwind.test.tsx
+++ b/packages/tailwind/test/tailwind.test.tsx
@@ -306,7 +306,7 @@ describe('<Tailwind> component', () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<html data-id=\\"@jsx-email/html\\" lang=\\"en\\" dir=\\"ltr\\"><head data-id=\\"@jsx-email/head\\"><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"/><style>@media(min-width:640px){.sm\\\\:text-sm{font-size:0.875rem;line-height:1.25rem}.sm\\\\:bg-red-50{background-color:rgb(254,242,242)}}@media(min-width:768px){.md\\\\:text-lg{font-size:1.125rem;line-height:1.75rem}}</style></head><span><!--[if mso]><i style=\\"letter-spacing: 10px;mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><div class=\\"custom-class\\" style=\\"background-color:rgb(255,255,255)\\"></div></html>"'
+      '"<html data-id=\\"@jsx-email/html\\" lang=\\"en\\" dir=\\"ltr\\"><head data-id=\\"@jsx-email/head\\"><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"/><style>@media(min-width:640px){.sm\\\\:\\\\!text-sm{font-size:0.875rem !important;line-height:1.25rem !important}.sm\\\\:\\\\!bg-red-50{background-color:rgb(254,242,242) !important}}@media(min-width:768px){.md\\\\:\\\\!text-lg{font-size:1.125rem !important;line-height:1.75rem !important}}</style></head><span><!--[if mso]><i style=\\"letter-spacing: 10px;mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><div class=\\"custom-class sm:!bg-red-50 sm:!text-sm md:!text-lg\\" style=\\"background-color:rgb(255,255,255)\\"></div></html>"'
     );
   });
 
@@ -336,7 +336,7 @@ describe('<Tailwind> component', () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      '"<html data-id=\\"@jsx-email/html\\" lang=\\"en\\" dir=\\"ltr\\"><head data-id=\\"@jsx-email/head\\"><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"/><style>@media(min-width:1280px){.xl\\\\:bg-green-500{background-color:rgb(34,197,94)}}@media(min-width:1536px){.\\\\32xl\\\\:bg-blue-500{background-color:undefined}.\\\\32xl\\\\:bg-blue-500{background-color:rgb(59,130,246)}}</style></head><div>Test</div><div>Test</div></html>"'
+      '"<html data-id=\\"@jsx-email/html\\" lang=\\"en\\" dir=\\"ltr\\"><head data-id=\\"@jsx-email/head\\"><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"/><style>@media(min-width:1280px){.xl\\\\:\\\\!bg-green-500{background-color:rgb(34,197,94) !important}}@media(min-width:1536px){.\\\\32xl\\\\:\\\\!bg-blue-500{background-color:undefined !important}.\\\\32xl\\\\:\\\\!bg-blue-500{background-color:rgb(59,130,246) !important}}</style></head><div class=\\"xl:!bg-green-500\\">Test</div><div class=\\"2xl:!bg-blue-500\\">Test</div></html>"'
     );
   });
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:
Tailwind
This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.



### Description
Class names for tailwind media queries were not being kept after tailwind's transformation (an oversight).

The important declaration enables the responsive style to overwrite the `style` props on the element

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
