### PR TITLE
fix(cli): use yargs, pretty should be optional

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,8 @@
     "tailwindcss": "3.3.3",
     "titleize": "^4.0.0",
     "vite": "^4.4.9",
-    "vite-plugin-dynamic-import": "^1.5.0"
+    "vite-plugin-dynamic-import": "^1.5.0",
+    "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
     "@types/classnames": "2.3.1",
@@ -63,7 +64,8 @@
     "@types/html-minifier-terser": "^7.0.0",
     "@types/import-local": "^3.1.0",
     "@types/js-beautify": "^1.14.1",
-    "@types/mustache": "^4.2.3"
+    "@types/mustache": "^4.2.3",
+    "@types/yargs-parser": "^21.0.2"
   },
   "funding": {
     "type": "github",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -80,7 +80,7 @@ const prettify = (html: string) => {
 const normalizePath = (filename: string) => filename.split(win32.sep).join(posix.sep);
 
 const stripHtml = (html: string) => {
-  const $ = load(html, { xml: { decodeEntities: false }, xmlMode: true });
+  const $ = load(html, { xml: { decodeEntities: false }, xmlMode: true } as any);
 
   $('*').removeAttr('data-id');
 

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -10,7 +10,7 @@ import type { CommandFn } from './types';
 
 const PreviewOptionsStruct = object({
   host: optional(boolean()),
-  'no-open': optional(boolean()),
+  open: optional(boolean()),
   port: optional(union([number(), string()]))
 });
 
@@ -53,8 +53,7 @@ export const start = async (targetPath: string, argv: PreviewOptions) => {
     return;
   }
 
-  const { host = false, port = 55420 } = argv;
-  const open = !argv['no-open'];
+  const { host = false, open = true, port = 55420 } = argv;
   const { default: config } = await import('../../app/vite.config');
 
   const mergedConfig = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
-import { parseArgs } from 'node:util';
-
 import debugConfig from 'debug';
 import importLocal from 'import-local';
+import yargs from 'yargs-parser';
 
 import pkg from '../package.json';
 
@@ -17,20 +16,22 @@ const debug = debugConfig('@jsx-email/cli');
 const { log } = console;
 
 const run = async () => {
-  const argv = parseArgs({ allowPositionals: true, args: process.argv.slice(2), strict: false });
-  const [commandName] = argv.positionals;
+  const argv = yargs(process.argv.slice(2));
+  const { _: positionals, ...flags } = argv;
+  const [commandName] = positionals;
   let command = commands[commandName];
 
   debug(`Command Name: \`${commandName}\``);
 
-  if (argv.values.version) {
+  if (flags.version) {
     log(`${pkg.name} v${pkg.version}\n`);
     return;
   }
 
   if (!command) command = help;
 
-  const result = await command(argv.values, argv.positionals?.slice(1) || []);
+  const input = (positionals.slice(1) as string[]) || [];
+  const result = await command(flags, input);
 
   if (!result) {
     debug(`Command \`${commandName}\` returned \`false\``);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,9 @@ importers:
       vite-plugin-dynamic-import:
         specifier: ^1.5.0
         version: 1.5.0
+      yargs-parser:
+        specifier: ^21.1.1
+        version: 21.1.1
     devDependencies:
       '@types/classnames':
         specifier: 2.3.1
@@ -360,6 +363,9 @@ importers:
       '@types/mustache':
         specifier: ^4.2.3
         version: 4.2.3
+      '@types/yargs-parser':
+        specifier: ^21.0.2
+        version: 21.0.2
 
   packages/column:
     dependencies:
@@ -2734,6 +2740,10 @@ packages:
 
   /@types/web-bluetooth@0.0.17:
     resolution: {integrity: sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==}
+    dev: true
+
+  /@types/yargs-parser@21.0.2:
+    resolution: {integrity: sha512-5qcvofLPbfjmBfKaLfj/+f+Sbd6pN4zl7w7VSVI5uz7m9QZTuB2aZAa2uo1wHFBNN2x6g/SoTkXmd8mQnQF2Cw==}
     dev: true
 
   /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.27.0)(typescript@5.2.2):
@@ -7771,7 +7781,6 @@ packages:
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
-    dev: true
 
   /yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This switches up the CLI to use `yargs-parser` as `parseArgs` builtin is just lacking. Also makes pretty print optional and false by default, as was intended. 