### PR TITLE
feat(render)!: `Suspense` and psuedo-async component support

### DIFF
--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -41,11 +41,13 @@
     "cheerio": "1.0.0-rc.12",
     "html-minifier-terser": "^7.2.0",
     "html-to-text": "9.0.5",
+    "object-hash": "^3.0.0",
     "pretty": "2.0.0"
   },
   "devDependencies": {
     "@types/html-minifier-terser": "^7.0.0",
     "@types/html-to-text": "^9.0.2",
+    "@types/object-hash": "^3.0.6",
     "@types/pretty": "^2.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/render/src/jsx-to-string.ts
+++ b/packages/render/src/jsx-to-string.ts
@@ -90,7 +90,7 @@ const EMPTY_OBJECT = Object.freeze({});
 
 const promiseMap = new Map();
 
-export function wrapPromise<TPromise extends Promise<any>>(promise: TPromise) {
+const wrapPromise = <TPromise extends Promise<any>>(promise: TPromise) => {
   let status = 'pending';
   let result: Awaited<TPromise>;
   const suspender = promise.then(
@@ -115,7 +115,7 @@ export function wrapPromise<TPromise extends Promise<any>>(promise: TPromise) {
       }
     }
   };
-}
+};
 
 export const useData = <TData>(props: any, cb: () => Promise<TData>): TData => {
   const key = hash(props);

--- a/packages/render/src/jsx-to-string.ts
+++ b/packages/render/src/jsx-to-string.ts
@@ -3,7 +3,6 @@
  * @license MIT
  */
 
-// import pThrottle from 'p-throttle';
 import type { FC, ReactNode } from 'react';
 import hash from 'object-hash';
 
@@ -91,7 +90,6 @@ const EMPTY_OBJECT = Object.freeze({});
 
 const promiseMap = new Map();
 
-/** the good old wrapPromise **/
 export function wrapPromise<TPromise extends Promise<any>>(promise: TPromise) {
   let status = 'pending';
   let result: Awaited<TPromise>;

--- a/packages/render/src/jsx-to-string.ts
+++ b/packages/render/src/jsx-to-string.ts
@@ -3,7 +3,9 @@
  * @license MIT
  */
 
+// import pThrottle from 'p-throttle';
 import type { FC, ReactNode } from 'react';
+import hash from 'object-hash';
 
 import { escapeString } from './escape-string';
 import { stringifyStyles } from './stringify-styles';
@@ -87,6 +89,61 @@ const VOID_ELEMENTS = new Set([
 
 const EMPTY_OBJECT = Object.freeze({});
 
+const promiseMap = new Map();
+
+/** the good old wrapPromise **/
+export function wrapPromise<TPromise extends Promise<any>>(promise: TPromise) {
+  let status = 'pending';
+  let result: Awaited<TPromise>;
+  const suspender = promise.then(
+    (r) => {
+      status = 'success';
+      result = r;
+    },
+    (e) => {
+      status = 'error';
+      result = e;
+    }
+  );
+  return {
+    // eslint-disable-next-line consistent-return
+    read() {
+      if (status === 'pending') {
+        throw suspender;
+      } else if (status === 'error') {
+        throw result;
+      } else if (status === 'success') {
+        return result;
+      }
+    }
+  };
+}
+
+export const useData = <TData>(props: any, cb: () => Promise<TData>): TData => {
+  const key = hash(props);
+  let dataPromise;
+  if (promiseMap.has(key)) {
+    dataPromise = promiseMap.get(key);
+  } else {
+    dataPromise = wrapPromise(cb());
+    promiseMap.set(key, dataPromise);
+  }
+  return dataPromise.read();
+};
+
+const renderSuspense = async (children: ReactNode[]): ReturnType<typeof jsxToString> => {
+  try {
+    const result = await jsxToString(children);
+    return result;
+  } catch (error) {
+    if (error instanceof Promise) {
+      await error;
+      return renderSuspense(children);
+    }
+    throw error;
+  }
+};
+
 /**
  * Convert a JSX element to a string.
  * This is a slightly modified version of Hyperons's
@@ -95,7 +152,7 @@ const EMPTY_OBJECT = Object.freeze({});
  * @param element The JSX element to convert to a string
  * @returns The string representation of the JSX element
  */
-export function jsxToString(element: ReactNode): string {
+export async function jsxToString(element: ReactNode): Promise<string> {
   if (element == null) {
     return '';
   }
@@ -108,7 +165,8 @@ export function jsxToString(element: ReactNode): string {
   } else if (isIterable(element)) {
     let html = '';
     for (const child of element) {
-      html += jsxToString(child);
+      // eslint-disable-next-line no-await-in-loop
+      html += await jsxToString(child);
     }
     return html;
   }
@@ -162,7 +220,7 @@ export function jsxToString(element: ReactNode): string {
       if (innerHTML) {
         html += innerHTML;
       } else {
-        html += jsxToString(props.children);
+        html += await jsxToString(props.children);
       }
 
       html += `</${type}>`;
@@ -173,15 +231,20 @@ export function jsxToString(element: ReactNode): string {
     if (typeof type === 'function') {
       return jsxToString((type as FC)(props));
     } else if (typeof type === 'symbol') {
+      const key = Symbol.keyFor(type);
       // is this react fragment?
-      if (Symbol.keyFor(type) === 'react.fragment') {
+      if (key === 'react.fragment') {
         return jsxToString(props.children);
+      } else if (key === 'react.suspense') {
+        const suspenseResult = await renderSuspense(props.children);
+        return suspenseResult;
       }
     } else if (isReactForwardRef(type)) {
       return jsxToString(
         (type as { render: (props: unknown, ref: unknown) => ReactNode }).render(props, props.ref)
       );
     }
+
     throw new Error(`Unsupported JSX element type: ${String(type)}`);
   }
   return '';

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -39,13 +39,15 @@ const stripHtml = (html: string) => {
   return $.html()!;
 };
 
-const renderPlainText = (component: React.ReactElement, _options?: Options) =>
-  convert(jsxToString(component), {
+const renderPlainText = async (component: React.ReactElement, _options?: Options) => {
+  const result = await jsxToString(component);
+  return convert(result, {
     selectors: [
       { format: 'skip', selector: 'img' },
       { format: 'skip', selector: '[data-id="@jsx-email/preview"]' }
     ]
   });
+};
 
 export const render = async (component: React.ReactElement, options?: Options) => {
   const { minify, plainText, pretty, strip = true } = options || {};
@@ -54,7 +56,7 @@ export const render = async (component: React.ReactElement, options?: Options) =
 
   const doctype =
     '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
-  const markup = jsxToString(component);
+  const markup = await jsxToString(component);
   let html = `${doctype}${markup}`;
 
   html = combineHeads(html);

--- a/packages/render/test/.snapshots/suspense.test.tsx.snap
+++ b/packages/render/test/.snapshots/suspense.test.tsx.snap
@@ -1,3 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`render > processes an async component 1`] = `"<div>donezo</div><h1>Welcome, Jim!</h1><img src=\\"img/test.png\\" alt=\\"test\\"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p>"`;
+
+exports[`render > renders an async component 1`] = `"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><div>donezo</div><h1>Welcome, Jim!</h1><img src=\\"img/test.png\\" alt=\\"test\\"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p>"`;

--- a/packages/render/test/.snapshots/suspense.test.tsx.snap
+++ b/packages/render/test/.snapshots/suspense.test.tsx.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`render > processes an async component 1`] = `"<div>donezo</div><h1>Welcome, Jim!</h1><img src=\\"img/test.png\\" alt=\\"test\\"/><p>Thanks for trying our product. We&#x27;re thrilled to have you on board!</p>"`;

--- a/packages/render/test/fixtures/async-template.tsx
+++ b/packages/render/test/fixtures/async-template.tsx
@@ -1,0 +1,33 @@
+import React, { Suspense } from 'react';
+
+import { useData } from '../../src/jsx-to-string';
+
+interface TemplateProps {
+  firstName: string;
+}
+
+const Async = (props: any) => {
+  const res = useData(
+    props,
+    () =>
+      new Promise<string>((resolve) => {
+        setTimeout(() => {
+          resolve('donezo');
+        }, 2000);
+      })
+  );
+
+  return <div>{res}</div>;
+};
+
+export const Template: React.FC<Readonly<TemplateProps>> = ({ firstName }) => (
+  <>
+    <Suspense fallback={<div>waiting</div>}>
+      <Async />
+    </Suspense>
+
+    <h1>Welcome, {firstName}!</h1>
+    <img src="img/test.png" alt="test" />
+    <p>Thanks for trying our product. We're thrilled to have you on board!</p>
+  </>
+);

--- a/packages/render/test/jsx-to-string.test.tsx
+++ b/packages/render/test/jsx-to-string.test.tsx
@@ -17,52 +17,52 @@ const Template: FC<{
   </>
 );
 
-describe('jsx-to-string', () => {
-  it('converts a React component into HTML', () => {
-    const actualOutput = jsxToString(<Template firstName="Jim" />);
+describe('jsx-to-string', async () => {
+  it('converts a React component into HTML', async () => {
+    const actualOutput = await jsxToString(<Template firstName="Jim" />);
     expect(actualOutput).toMatchSnapshot();
   });
 
-  describe('elements', () => {
-    it('renders simple elements', () => {
-      const result = jsxToString(<div></div>);
+  describe('elements', async () => {
+    it('renders simple elements', async () => {
+      const result = await jsxToString(<div></div>);
       expect(result).toBe('<div></div>');
     });
 
-    it('renders void elements', () => {
-      const result = jsxToString(<br />);
+    it('renders void elements', async () => {
+      const result = await jsxToString(<br />);
       expect(result).toBe('<br/>');
     });
 
-    it('does not render fragments', () => {
-      const result = jsxToString(<></>);
+    it('does not render fragments', async () => {
+      const result = await jsxToString(<></>);
       expect(result).toBe('');
     });
 
-    it('invokes functional components', () => {
+    it('invokes functional components', async () => {
       const Component = (props: { text: string }) => <span className="c">{props.text}</span>;
-      const result = jsxToString(<Component text="Hello World" />);
+      const result = await jsxToString(<Component text="Hello World" />);
       expect(result).toBe('<span class="c">Hello World</span>');
     });
 
-    it('does not render null', () => {
-      expect(jsxToString(null)).toBe('');
+    it('does not render null', async () => {
+      expect(await jsxToString(null)).toBe('');
     });
 
-    it('does not render booleans', () => {
-      expect(jsxToString(true)).toBe('');
-      expect(jsxToString(false)).toBe('');
+    it('does not render booleans', async () => {
+      expect(await jsxToString(true)).toBe('');
+      expect(await jsxToString(false)).toBe('');
     });
   });
 
-  describe('properties', () => {
-    it('renders HTML attribute names and values', () => {
-      const result = jsxToString(<form action="/submit" method="post" />);
+  describe('properties', async () => {
+    it('renders HTML attribute names and values', async () => {
+      const result = await jsxToString(<form action="/submit" method="post" />);
       expect(result).toBe('<form action="/submit" method="post"></form>');
     });
 
-    it('does not render null or undefined HTML attributes', () => {
-      const result = jsxToString(
+    it('does not render null or undefined HTML attributes', async () => {
+      const result = await jsxToString(
         // @ts-expect-error because null is not a valid value for the `itemType` attribute
         // eslint-disable-next-line no-undefined
         <div itemType={null} itemProp={undefined} className={undefined} />
@@ -70,83 +70,87 @@ describe('jsx-to-string', () => {
       expect(result).toBe('<div></div>');
     });
 
-    it('ignores framework specific properties', () => {
-      const result = jsxToString(<div key="item" children={[]} />);
+    it('ignores framework specific properties', async () => {
+      const result = await jsxToString(<div key="item" children={[]} />);
       expect(result).toBe('<div></div>');
     });
 
-    it('aliases conflicting JS keywords', () => {
-      const result = jsxToString(<label className="label" htmlFor="id" />);
+    it('aliases conflicting JS keywords', async () => {
+      const result = await jsxToString(<label className="label" htmlFor="id" />);
       expect(result).toBe('<label class="label" for="id"></label>');
     });
 
-    it('lowercases camelCase attribute names', () => {
-      const result = jsxToString(<input tabIndex={-1} defaultValue="Hello" />);
+    it('lowercases camelCase attribute names', async () => {
+      const result = await jsxToString(<input tabIndex={-1} defaultValue="Hello" />);
       expect(result).toBe('<input tabindex="-1" value="Hello"/>');
     });
 
-    it('escapes HTML attribute values', () => {
-      const result = jsxToString(<img alt='"Mac & Cheese"' />);
+    it('escapes HTML attribute values', async () => {
+      const result = await jsxToString(<img alt='"Mac & Cheese"' />);
       expect(result).toBe('<img alt="&quot;Mac &amp; Cheese&quot;"/>');
     });
 
-    describe('boolean attributes', () => {
-      it('does not append boolean attributes with a falsy value', () => {
+    describe('boolean attributes', async () => {
+      it('does not append boolean attributes with a falsy value', async () => {
         // @ts-expect-error because `open` is a boolean attribute.
-        const result = jsxToString(<details hidden={false} open={0} />);
+        const result = await jsxToString(<details hidden={false} open={0} />);
         expect(result).toBe('<details></details>');
       });
 
-      it('appends boolean attributes with a truthy value', () => {
+      it('appends boolean attributes with a truthy value', async () => {
         // @ts-expect-error because `open` is a boolean attribute.
-        const result = jsxToString(<details hidden={true} open={1} />);
+        const result = await jsxToString(<details hidden={true} open={1} />);
         expect(result).toBe('<details hidden open></details>');
       });
 
-      it('renders boolean values for enumerable attributes', () => {
-        const result = jsxToString(<div contentEditable={true} spellCheck={false} />);
+      it('renders boolean values for enumerable attributes', async () => {
+        const result = await jsxToString(<div contentEditable={true} spellCheck={false} />);
         expect(result).toBe('<div contenteditable="true" spellcheck="false"></div>');
       });
     });
 
-    describe('styles', () => {
-      it('stringifies style attributes', () => {
-        const result = jsxToString(<div style={{ margin: '1em 0', padding: '0.5em 1em' }} />);
+    describe('styles', async () => {
+      it('stringifies style attributes', async () => {
+        const result = await jsxToString(<div style={{ margin: '1em 0', padding: '0.5em 1em' }} />);
         expect(result).toBe('<div style="margin:1em 0;padding:0.5em 1em"></div>');
       });
 
-      it('hyphenates style properties', () => {
-        const result = jsxToString(<div style={{ marginBottom: '1em', paddingTop: '0.5em' }} />);
+      it('hyphenates style properties', async () => {
+        const result = await jsxToString(
+          <div style={{ marginBottom: '1em', paddingTop: '0.5em' }} />
+        );
         expect(result).toBe('<div style="margin-bottom:1em;padding-top:0.5em"></div>');
       });
 
-      it('hyphenates vendor prefixed properties', () => {
-        const result = jsxToString(<div style={{ MozHyphens: 'auto', msHyphens: 'auto' }} />);
+      it('hyphenates vendor prefixed properties', async () => {
+        const result = await jsxToString(<div style={{ MozHyphens: 'auto', msHyphens: 'auto' }} />);
         expect(result).toBe('<div style="-moz-hyphens:auto;-ms-hyphens:auto"></div>');
       });
 
-      it('applies pixel units to number values', () => {
-        const result = jsxToString(<div style={{ margin: 20, padding: 10 }} />);
+      it('applies pixel units to number values', async () => {
+        const result = await jsxToString(<div style={{ margin: 20, padding: 10 }} />);
         expect(result).toBe('<div style="margin:20px;padding:10px"></div>');
       });
 
-      it('does not apply pixel values to unitless properties', () => {
-        const result = jsxToString(<div style={{ flexShrink: 1, order: 2 }} />);
+      it('does not apply pixel values to unitless properties', async () => {
+        const result = await jsxToString(<div style={{ flexShrink: 1, order: 2 }} />);
         expect(result).toBe('<div style="flex-shrink:1;order:2"></div>');
       });
 
-      it('ignores null or undefined properties', () => {
-        // @ts-expect-error because `width`, height` and `border` are not valid style properties.
-        // eslint-disable-next-line no-undefined
-        const result = jsxToString(<div style={{ border: 0, height: undefined, width: null }} />);
+      it('ignores null or undefined properties', async () => {
+        const result = await jsxToString(
+          // @ts-expect-error because `width`, height` and `border` are not valid style properties.
+          // eslint-disable-next-line no-undefined
+          <div style={{ border: 0, height: undefined, width: null }} />
+        );
         expect(result).toBe('<div style="border:0"></div>');
       });
     });
   });
 
-  describe('children', () => {
-    it('ignores empty children', () => {
-      const result = jsxToString(
+  describe('children', async () => {
+    it('ignores empty children', async () => {
+      const result = await jsxToString(
         <div>
           {/* eslint-disable-next-line no-undefined */}
           {undefined}
@@ -156,36 +160,36 @@ describe('jsx-to-string', () => {
       expect(result).toBe('<div></div>');
     });
 
-    it('renders text children', () => {
-      const result = jsxToString(<div>Hello World</div>);
+    it('renders text children', async () => {
+      const result = await jsxToString(<div>Hello World</div>);
       expect(result).toBe('<div>Hello World</div>');
     });
 
-    it('renders numeric children', () => {
-      const result = jsxToString(<div>{123}</div>);
+    it('renders numeric children', async () => {
+      const result = await jsxToString(<div>{123}</div>);
       expect(result).toBe('<div>123</div>');
     });
 
-    it('renders numeric children even if they are zero', () => {
-      const result = jsxToString(<div>{0}</div>);
+    it('renders numeric children even if they are zero', async () => {
+      const result = await jsxToString(<div>{0}</div>);
       expect(result).toBe('<div>0</div>');
     });
 
-    it('does not render boolean children', () => {
-      const a = jsxToString(<div>{true}</div>);
+    it('does not render boolean children', async () => {
+      const a = await jsxToString(<div>{true}</div>);
       expect(a).toBe('<div></div>');
 
-      const b = jsxToString(<div>{false}</div>);
+      const b = await jsxToString(<div>{false}</div>);
       expect(b).toBe('<div></div>');
     });
 
-    it('escapes text children', () => {
-      const result = jsxToString(<div>{'"Mac & Cheese"'}</div>);
+    it('escapes text children', async () => {
+      const result = await jsxToString(<div>{'"Mac & Cheese"'}</div>);
       expect(result).toBe('<div>&quot;Mac &amp; Cheese&quot;</div>');
     });
 
-    it('renders multiple children', () => {
-      const result = jsxToString(
+    it('renders multiple children', async () => {
+      const result = await jsxToString(
         <div>
           <i>Hello</i> <i>World</i>!
         </div>
@@ -193,16 +197,16 @@ describe('jsx-to-string', () => {
       expect(result).toBe('<div><i>Hello</i> <i>World</i>!</div>');
     });
 
-    it('renders nested children', () => {
-      const result = jsxToString(
+    it('renders nested children', async () => {
+      const result = await jsxToString(
         <div>{[<i key={1}>Hello</i>, [' ', [<i key={2}>World</i>, '!']]]}</div>
       );
       expect(result).toBe('<div><i>Hello</i> <i>World</i>!</div>');
     });
 
-    it('passes children to compositional components', () => {
+    it('passes children to compositional components', async () => {
       const Parent = (props: { children: ReactNode }) => <ul>{props.children}</ul>;
-      const result = jsxToString(
+      const result = await jsxToString(
         <Parent>
           <li>one</li>
           <li>two</li>
@@ -212,18 +216,18 @@ describe('jsx-to-string', () => {
       expect(result).toBe('<ul><li>one</li><li>two</li></ul>');
     });
 
-    it('it allows children provided as props', () => {
+    it('it allows children provided as props', async () => {
       const Parent = (props: { children: ReactNode }) => <ul>{props.children}</ul>;
-      const result = jsxToString(
+      const result = await jsxToString(
         <Parent children={[<li key={1}>one</li>, <li key={2}>two</li>]} />
       );
 
       expect(result).toBe('<ul><li>one</li><li>two</li></ul>');
     });
 
-    it('favours children provided as arguments over props', () => {
+    it('favours children provided as arguments over props', async () => {
       const Parent = (props: { children: ReactNode }) => <ul>{props.children}</ul>;
-      const result = jsxToString(
+      const result = await jsxToString(
         // @ts-expect-error because `children` is specified twice
         <Parent children={[<li>one</li>, <li>two</li>]}>
           <li>three</li>
@@ -233,13 +237,15 @@ describe('jsx-to-string', () => {
       expect(result).toBe('<ul><li>three</li></ul>');
     });
 
-    it('supports setting inner HTML', () => {
-      const result = jsxToString(<div dangerouslySetInnerHTML={{ __html: '<i>Hello</i>' }} />);
+    it('supports setting inner HTML', async () => {
+      const result = await jsxToString(
+        <div dangerouslySetInnerHTML={{ __html: '<i>Hello</i>' }} />
+      );
       expect(result).toBe('<div><i>Hello</i></div>');
     });
 
-    it('renders the children of fragments', () => {
-      const result = jsxToString(
+    it('renders the children of fragments', async () => {
+      const result = await jsxToString(
         <dl>
           <>
             <dt>Title</dt>

--- a/packages/render/test/render.tsx
+++ b/packages/render/test/render.tsx
@@ -1,0 +1,10 @@
+// Note: This is a manual test script. Run with: ts-node packages/render/test/render.tsx
+
+import { render } from '../src/render';
+
+import { Template } from './fixtures/async-template';
+
+(async () => {
+  const result = await render(<Template firstName="Jim" />);
+  console.log({ result });
+})();

--- a/packages/render/test/suspense.test.tsx
+++ b/packages/render/test/suspense.test.tsx
@@ -1,4 +1,4 @@
-// import { render } from '../src/render';
+import { render } from '../src/render';
 import { jsxToString } from '../src/jsx-to-string';
 
 import { Template } from './fixtures/async-template';
@@ -14,8 +14,8 @@ describe('render', () => {
     expect(result).toMatchSnapshot();
   });
 
-  // it('renders an async component', async () => {
-  //   const result = await render(<Template firstName="Jim" />);
-  //   expect(result).toMatchSnapshot();
-  // });
+  it('renders an async component', async () => {
+    const result = await render(<Template firstName="Jim" />);
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/render/test/suspense.test.tsx
+++ b/packages/render/test/suspense.test.tsx
@@ -1,0 +1,21 @@
+// import { render } from '../src/render';
+import { jsxToString } from '../src/jsx-to-string';
+
+import { Template } from './fixtures/async-template';
+
+describe('render', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('processes an async component', async () => {
+    const result = await jsxToString(<Template firstName="Jim" />);
+    expect(result).toMatchSnapshot();
+  });
+
+  // it('renders an async component', async () => {
+  //   const result = await render(<Template firstName="Jim" />);
+  //   expect(result).toMatchSnapshot();
+  // });
+});

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@jsx-email/render": "workspace:*",
     "cheerio": "1.0.0-rc.12",
+    "react-promise-suspense": "^0.3.4",
     "twind": "^0.16.19"
   },
   "devDependencies": {

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@jsx-email/render": "workspace:*",
     "cheerio": "1.0.0-rc.12",
-    "react-promise-suspense": "^0.3.4",
     "twind": "^0.16.19"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,9 +500,6 @@ importers:
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
-      react-promise-suspense:
-        specifier: ^0.3.4
-        version: 0.3.4
       twind:
         specifier: ^0.16.19
         version: 0.16.19(typescript@5.2.2)
@@ -4469,10 +4466,6 @@ packages:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
     dev: false
 
-  /fast-deep-equal@2.0.1:
-    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
-    dev: false
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -6308,12 +6301,6 @@ packages:
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
-
-  /react-promise-suspense@0.3.4:
-    resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
-    dependencies:
-      fast-deep-equal: 2.0.1
-    dev: false
 
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -454,6 +454,9 @@ importers:
       html-to-text:
         specifier: 9.0.5
         version: 9.0.5
+      object-hash:
+        specifier: ^3.0.0
+        version: 3.0.0
       pretty:
         specifier: 2.0.0
         version: 2.0.0
@@ -464,6 +467,9 @@ importers:
       '@types/html-to-text':
         specifier: ^9.0.2
         version: 9.0.2
+      '@types/object-hash':
+        specifier: ^3.0.6
+        version: 3.0.6
       '@types/pretty':
         specifier: ^2.0.1
         version: 2.0.1
@@ -494,6 +500,9 @@ importers:
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
+      react-promise-suspense:
+        specifier: ^0.3.4
+        version: 0.3.4
       twind:
         specifier: ^0.16.19
         version: 0.16.19(typescript@5.2.2)
@@ -2701,6 +2710,10 @@ packages:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
 
+  /@types/object-hash@3.0.6:
+    resolution: {integrity: sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==}
+    dev: true
+
   /@types/pretty@2.0.1:
     resolution: {integrity: sha512-l18spTC0Q2OEUIHGPyw37XBOacFI4Kng1fgfFjgDTg2FR9wqJ/NY9zWyXv87NRUlFDU6JA+E/GVnNJiWgyon6A==}
     dev: true
@@ -4454,6 +4467,10 @@ packages:
 
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
+
+  /fast-deep-equal@2.0.1:
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
     dev: false
 
   /fast-deep-equal@3.1.3:
@@ -6291,6 +6308,12 @@ packages:
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
+
+  /react-promise-suspense@0.3.4:
+    resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
+    dependencies:
+      fast-deep-equal: 2.0.1
+    dev: false
 
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: `render`

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR adds support for server side rendering of `Suspense` and psuedo-async components.

For in-browser React compatibility, we're supporting `Suspense` via the `useData` utility, which works along side of a custom `Promise` wrapper. It's not likely that React's `lazy` is supported - it's untested and not likely to be needed for email rendering. 