### PR TITLE
feat(jsx-email): show html size, warn if over gmail threshold

### DIFF
--- a/packages/jsx-email/package.json
+++ b/packages/jsx-email/package.json
@@ -78,6 +78,7 @@
     "postcss": "^8.4.30",
     "postcss-var-replace": "^1.0.0",
     "pretty": "2.0.0",
+    "pretty-bytes": "^5.6.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "6.16.0",

--- a/packages/jsx-email/src/cli/helpers.ts
+++ b/packages/jsx-email/src/cli/helpers.ts
@@ -1,0 +1,15 @@
+import chalk from 'chalk';
+import prettyBytes from 'pretty-bytes';
+
+// 102kb
+export const gmailByteLimit = 102e3;
+export const gmailBytesSafe = 102e3 - 20e3;
+
+export const formatBytes = (bytes: number) => {
+  const pretty = prettyBytes(bytes);
+
+  if (bytes > gmailByteLimit) return chalk.red(pretty);
+  else if (bytes > gmailBytesSafe - 20e3) return chalk.red(pretty);
+
+  return chalk.green(pretty);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       pretty:
         specifier: 2.0.0
         version: 2.0.0
+      pretty-bytes:
+        specifier: ^5.6.0
+        version: 5.6.0
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -6277,6 +6280,11 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
+
+  /pretty-bytes@5.6.0:
+    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
+    engines: {node: '>=6'}
+    dev: false
 
   /pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: jsx-email

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR introduces the display of the generated HTML size on disk. Gmail in particular has a message clipping threshold of 102kb. With these changes it's easy to see at a glance if an email template is exceeding that threshold when running `email build`. The `email check` command will now display errors (over the threshold) or warnings (near the threshold) for email template output.


<img width="452" alt="Screenshot 2023-12-02 at 10 22 00 AM" src="https://github.com/shellscape/jsx-email/assets/76371/8e242a73-844c-4233-bab9-c0848b7b7c17">

<img width="492" alt="Screenshot 2023-12-02 at 10 23 00 AM" src="https://github.com/shellscape/jsx-email/assets/76371/bc498341-cc80-456b-80e4-25a0a82bcdf4">

<img width="354" alt="Screenshot 2023-12-02 at 10 23 09 AM" src="https://github.com/shellscape/jsx-email/assets/76371/ab593992-271d-4d52-8d02-c19d07a2c093">
