### PR TITLE
fix(tailwind): add prefix to production class names

### DIFF
--- a/packages/jsx-email/src/components/tailwind/tailwind.tsx
+++ b/packages/jsx-email/src/components/tailwind/tailwind.tsx
@@ -32,7 +32,7 @@ const getUno = (config: ConfigBase, production: boolean) => {
   if (production)
     transformers.push(
       transformerCompileClass({
-        classPrefix: 'je',
+        classPrefix: 'je-',
         trigger: ':jsx:'
       })
     );

--- a/packages/jsx-email/src/components/tailwind/tailwind.tsx
+++ b/packages/jsx-email/src/components/tailwind/tailwind.tsx
@@ -32,7 +32,7 @@ const getUno = (config: ConfigBase, production: boolean) => {
   if (production)
     transformers.push(
       transformerCompileClass({
-        classPrefix: '',
+        classPrefix: 'je',
         trigger: ':jsx:'
       })
     );

--- a/packages/jsx-email/test/tailwind/.snapshots/tailwind.test.tsx.snap
+++ b/packages/jsx-email/test/tailwind/.snapshots/tailwind.test.tsx.snap
@@ -66,6 +66,12 @@ exports[`Custom theme config > should be able to use custom text alignment 1`] =
 .text-justify{text-align:justify;}</style></div>"
 `;
 
+exports[`Production mode > should generate class names with a prefix 1`] = `
+"<div data-id=\\"__jsx-email-twnd\\"><html data-id=\\"jsx-email/html\\" lang=\\"en\\" dir=\\"ltr\\"><div class=\\"je-5wyw0k\\"></div></html><style tailwind>/* layer: preflights */
+/* layer: shortcuts */
+.je-5wyw0k{background-color:rgb(254,226,226);font-size:0.875rem;line-height:1.25rem;}</style></div>"
+`;
+
 exports[`Responsive styles > should add css to <head/> 1`] = `
 "<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><html><head><style tailwind>/* layer: preflights */
 /* layer: default */

--- a/packages/jsx-email/test/tailwind/tailwind.test.tsx
+++ b/packages/jsx-email/test/tailwind/tailwind.test.tsx
@@ -259,3 +259,17 @@ describe('<Tailwind> component', async () => {
     );
   });
 });
+
+describe('Production mode', async () => {
+  it('should generate class names with a prefix', async () => {
+    const actualOutput = await jsxToString(
+      <Tailwind production>
+        <Html>
+          <div className="text-sm bg-red-100" />
+        </Html>
+      </Tailwind>
+    );
+
+    expect(actualOutput).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: jsx-email (Tailwind)

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:
resolves #110
<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This PR adds a prefix to the class names generated by the class compiler transformer. This is to ensure that the class names generated, which may begin with a number, do not need to be escaped in the generated CSS, thus increasing compatibility with gmail clients
