### PR TITLE
fix(jsx-email): shikiji error while using cjs, auto import react

### DIFF
--- a/packages/jsx-email/src/cli/commands/build.ts
+++ b/packages/jsx-email/src/cli/commands/build.ts
@@ -121,6 +121,8 @@ const compile = async (files: string[], outDir: string) => {
   await esbuild.build({
     bundle: true,
     entryPoints: files,
+    external: ['jsx-email', 'react'],
+    jsx: 'automatic',
     logLevel: 'error',
     outdir: outDir,
     platform: 'node',

--- a/packages/jsx-email/src/components/code.tsx
+++ b/packages/jsx-email/src/components/code.tsx
@@ -1,6 +1,6 @@
 import mem from 'p-memoize';
 import { Suspense } from 'react';
-import { getHighlighter as getHighBro, type BuiltinLanguage } from 'shikiji';
+import { type BuiltinLanguage } from 'shikiji';
 
 import { useData } from '../render/jsx-to-string';
 import type { BaseProps, JsxEmailComponent } from '../types';
@@ -14,6 +14,7 @@ export interface CodeProps extends RootProps {
 }
 
 const getHighlighter = mem(async (language?: string, theme = 'nord') => {
+  const { getHighlighter: getHighBro } = await import('shikiji');
   const shiki = await getHighBro({
     langs: language ? [language] : [],
     themes: [theme]

--- a/packages/jsx-email/test/render/fixtures/async-template.tsx
+++ b/packages/jsx-email/test/render/fixtures/async-template.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 
 import { useData } from '../../../src/render/jsx-to-string';
 

--- a/packages/jsx-email/test/render/fixtures/preview.tsx
+++ b/packages/jsx-email/test/render/fixtures/preview.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 interface PreviewProps {}
 
 export const Preview: React.FC<Readonly<PreviewProps>> = () => (

--- a/packages/jsx-email/test/render/fixtures/template.tsx
+++ b/packages/jsx-email/test/render/fixtures/template.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 interface TemplateProps {
   firstName: string;
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: jsx-email

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

Fixes #122

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR resolves an issue with using the package in commonjs, and also removes the need for templates to import `import React from 'react'`. 