### PR TITLE
fix(jsx-email): properly handle different preview props. fixes #132

### DIFF
--- a/apps/preview/app/src/main.tsx
+++ b/apps/preview/app/src/main.tsx
@@ -70,7 +70,8 @@ const templateRoutes = templates.map(async (template) => {
   let props: any;
 
   if (TemplateStruct) props = create({}, TemplateStruct);
-  else if (PreviewProps) props = PreviewProps();
+  else if (typeof PreviewProps === 'function') props = PreviewProps();
+  else if (PreviewProps) props = PreviewProps;
   else if ((Template as any).PreviewProps) {
     warn(
       `jsx-email: ${Name} → PreviewProps as a property of a component is deprecated. Please used a named export.`

--- a/apps/test/fixtures/default-export-props-fn.tsx
+++ b/apps/test/fixtures/default-export-props-fn.tsx
@@ -1,0 +1,16 @@
+import { Body, Html } from 'jsx-email';
+
+export const TemplateName = 'default-export-props-fn';
+
+const Template = ({ test }: { test: string }) => (
+  <Html>
+    <Body>{test}</Body>
+  </Html>
+);
+
+Template.PreviewProps = () => {
+  return { test: 'batman' };
+};
+
+// eslint-disable-next-line import/no-default-export
+export default Template;

--- a/apps/test/fixtures/default-export.tsx
+++ b/apps/test/fixtures/default-export.tsx
@@ -1,0 +1,14 @@
+import { Body, Html } from 'jsx-email';
+
+export const TemplateName = 'default-export';
+
+const Template = ({ test }: { test: string }) => (
+  <Html>
+    <Body>{test}</Body>
+  </Html>
+);
+
+Template.PreviewProps = { test: 'batman' };
+
+// eslint-disable-next-line import/no-default-export
+export default Template;

--- a/apps/test/fixtures/preview-props-fn.tsx
+++ b/apps/test/fixtures/preview-props-fn.tsx
@@ -1,0 +1,13 @@
+import { Body, Html } from 'jsx-email';
+
+export const TemplateName = 'preview-props-fn';
+
+export const Template = ({ test }: { test: string }) => (
+  <Html>
+    <Body>{test}</Body>
+  </Html>
+);
+
+Template.PreviewProps = () => {
+  return { test: 'batman' };
+};

--- a/apps/test/fixtures/preview-props-named.tsx
+++ b/apps/test/fixtures/preview-props-named.tsx
@@ -1,0 +1,11 @@
+import { Body, Html } from 'jsx-email';
+
+export const TemplateName = 'preview-props';
+
+export const Template = ({ test }: { test: string }) => (
+  <Html>
+    <Body>{test}</Body>
+  </Html>
+);
+
+export const PreviewProps = { test: 'batman' };

--- a/apps/test/fixtures/preview-props.tsx
+++ b/apps/test/fixtures/preview-props.tsx
@@ -1,0 +1,11 @@
+import { Body, Html } from 'jsx-email';
+
+export const TemplateName = 'preview-props';
+
+export const Template = ({ test }: { test: string }) => (
+  <Html>
+    <Body>{test}</Body>
+  </Html>
+);
+
+Template.PreviewProps = { test: 'batman' };

--- a/apps/test/tests/.snapshots/smoke.spec.ts-page-Default-Export-1-chromium.txt
+++ b/apps/test/tests/.snapshots/smoke.spec.ts-page-Default-Export-1-chromium.txt
@@ -1,0 +1,10 @@
+<html
+  lang="en"
+  dir="ltr"
+>
+  <head>
+  </head>
+  <body>
+    batman
+  </body>
+</html>

--- a/apps/test/tests/.snapshots/smoke.spec.ts-page-Default-Export-Props-Fn-1-chromium.txt
+++ b/apps/test/tests/.snapshots/smoke.spec.ts-page-Default-Export-Props-Fn-1-chromium.txt
@@ -1,0 +1,10 @@
+<html
+  lang="en"
+  dir="ltr"
+>
+  <head>
+  </head>
+  <body>
+    batman
+  </body>
+</html>

--- a/apps/test/tests/.snapshots/smoke.spec.ts-page-Preview-Props-1-chromium.txt
+++ b/apps/test/tests/.snapshots/smoke.spec.ts-page-Preview-Props-1-chromium.txt
@@ -1,0 +1,10 @@
+<html
+  lang="en"
+  dir="ltr"
+>
+  <head>
+  </head>
+  <body>
+    batman
+  </body>
+</html>

--- a/apps/test/tests/.snapshots/smoke.spec.ts-page-Preview-Props-Fn-1-chromium.txt
+++ b/apps/test/tests/.snapshots/smoke.spec.ts-page-Preview-Props-Fn-1-chromium.txt
@@ -1,0 +1,10 @@
+<html
+  lang="en"
+  dir="ltr"
+>
+  <head>
+  </head>
+  <body>
+    batman
+  </body>
+</html>

--- a/apps/test/tests/.snapshots/smoke.spec.ts-page-Preview-Props-Named-1-chromium.txt
+++ b/apps/test/tests/.snapshots/smoke.spec.ts-page-Preview-Props-Named-1-chromium.txt
@@ -1,0 +1,10 @@
+<html
+  lang="en"
+  dir="ltr"
+>
+  <head>
+  </head>
+  <body>
+    batman
+  </body>
+</html>

--- a/apps/test/tests/smoke.spec.ts
+++ b/apps/test/tests/smoke.spec.ts
@@ -19,7 +19,17 @@ test('landing', async ({ page }) => {
   await expect(page.locator('#link-Base')).toBeVisible();
 });
 
-const pages = ['Base', 'Code', 'Local-Assets', 'Tailwind'];
+const pages = [
+  'Base',
+  'Code',
+  'Default-Export',
+  'Default-Export-Props-Fn',
+  'Local-Assets',
+  'Preview-Props',
+  'Preview-Props-Fn',
+  'Preview-Props-Named',
+  'Tailwind'
+];
 
 pages.forEach((name) => {
   test(`page: ${name}`, async ({ page }) => {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: jsx-email

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Fixes #132 by properly handling `PreviewProps` exports