### PR TITLE
fix(jsx-email): revert excluding jsx-email+react during build. fixes #137

### DIFF
--- a/packages/jsx-email/src/cli/commands/build.ts
+++ b/packages/jsx-email/src/cli/commands/build.ts
@@ -121,7 +121,6 @@ const compile = async (files: string[], outDir: string) => {
   await esbuild.build({
     bundle: true,
     entryPoints: files,
-    external: ['jsx-email', 'react'],
     jsx: 'automatic',
     logLevel: 'error',
     outdir: outDir,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: jsx-email

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers: fixes #137

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This commit https://github.com/shellscape/jsx-email/commit/e0a7eb44a96b85fed54d918bd3a05b788606267d#diff-956e216fa7df03ccf64dcfcbe8fdacf5560897b6726255ff29c1c3c8cc757721R124 had the goal of reducing the size of the intermediary template output file which esbuild produces, and thus increasing speed. Unfortunately the way that pnpm, yarn, and npm differ in how they create binaries in node_modules/.bin causes an issue where yarn and npm have no idea about the path context of where the intermediate file will be run, hence it can't find node_modules and jsx-email.

Under pnpm, the binary file in node_modules/.bin contains path information whereas npm and yarn are just straight up copies of the target file. Under pnpm, the compiled template file has context as to where it's being run, so it can use the local node_modules. Apparently on npm/yarn, this is not the case.
