### PR TITLE
feat(jsx-email): add better environment variable support. fixes #139

### DIFF
--- a/apps/test/fixtures/env.tsx
+++ b/apps/test/fixtures/env.tsx
@@ -1,0 +1,4 @@
+import { Html } from 'jsx-email';
+import React from 'react';
+
+export const Template: React.FC<Readonly<any>> = () => <Html>{process.env.ENV_TEST_VALUE}</Html>;

--- a/apps/test/playwright.config.ts
+++ b/apps/test/playwright.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
   },
   webServer: {
     command: 'moon app-test:dev',
+    env: {
+      ENV_TEST_VALUE: 'joker'
+    },
     reuseExistingServer: !process.env.CI,
     url: 'http://localhost:55420'
   },

--- a/apps/test/tests/.snapshots/smoke.spec.ts-page-Env-1-chromium.txt
+++ b/apps/test/tests/.snapshots/smoke.spec.ts-page-Env-1-chromium.txt
@@ -1,0 +1,10 @@
+<html
+  lang="en"
+  dir="ltr"
+>
+  <head>
+  </head>
+  <body>
+    joker
+  </body>
+</html>

--- a/apps/test/tests/smoke.spec.ts
+++ b/apps/test/tests/smoke.spec.ts
@@ -24,6 +24,7 @@ const pages = [
   'Code',
   'Default-Export',
   'Default-Export-Props-Fn',
+  'Env',
   'Local-Assets',
   'Preview-Props',
   'Preview-Props-Fn',

--- a/packages/jsx-email/src/cli/commands/vite.ts
+++ b/packages/jsx-email/src/cli/commands/vite.ts
@@ -20,11 +20,25 @@ logger.warnOnce = (message, options) => {
   og(message, options);
 };
 
+// Note: This prepares a `define` object to inject all of the process' envars into vite. Vite is weird
+// in that it limits envars to those with a VITE_ prefix, but that's not a behavior that we need or
+// want for shipping vite as a wrapped dev server
+const envDefine = Object.keys(process.env)
+  .sort()
+  .reduce((agg, key) => {
+    agg[`process.env.${key}`] = JSON.stringify(process.env[key]);
+    return agg;
+  }, {} as Record<string, string | null>);
+
 export const viteConfig = defineConfig({
   clearScreen: false,
   customLogger: logger,
   define: {
-    'process.env': 'import.meta.env'
+    'process.env': 'import.meta.env',
+    // Note: vite appears to use a bottom-up (or reverse) strategy for applying defines. If the
+    // spread below is before the `process.env` define above, all of the keys we've defined in
+    // `envDefine` are replaced with an `import.meta.env` prefix, and thus don't work
+    ...envDefine
   },
   optimizeDeps: {
     // Note: These are all CommonJS dependencies that don't implement an ESM compatible exports

--- a/scripts/build-samples.ts
+++ b/scripts/build-samples.ts
@@ -8,7 +8,7 @@ import { build } from 'vite';
 process.chdir(join(__dirname, '../app'));
 
 (async () => {
-  const { viteConfig } = await import('../packages/jsx-email/src/cli/commands/vite.config');
+  const { viteConfig } = await import('../packages/jsx-email/src/cli/commands/vite');
   await build({
     ...viteConfig,
     build: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,5 @@
     "types": ["vitest/globals"]
   },
   "extends": "./shared/tsconfig.base.json",
-  "include": ["apps", "packages", "scripts", "shared", "./test.ts"]
+  "include": ["apps", "packages", "scripts", "shared"]
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: jsx-email

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers: Resolves #139 

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This adds better environment variable support to email templates for `email preview`. Previously, users would have to prefix any environment variables they wanted to use in templates (with the preview) with `VITE_` due to using Vite under the hood for the preview server. This is a poor experience. Changes in this PR make the full `process.env` value set available to templates for the preview app.