### PR TITLE
fix(app-preview): suppress erroneous react key errors

### DIFF
--- a/apps/preview/app/src/main.tsx
+++ b/apps/preview/app/src/main.tsx
@@ -16,6 +16,16 @@ import type { TemplatePart, TemplateData, TemplateExports } from './types.ts';
 const { warn } = console;
 const addSpacesForCamelCaseName = (str: string) => str.replace(/([a-z])([A-Z])/g, '$1 $2');
 
+// Note: Disables annoying key errors. We're static so we don't need to worry about this.
+/* eslint-disable no-console */
+const og = console.error;
+const re =
+  /^Warning: Each child in an array or iterator should have a unique "key" prop|^Warning: Each child in a list should have a unique "key" prop/;
+console.error = (...args) => {
+  const line = args[0];
+  if (!re.test(line)) og(...args);
+};
+
 const Layout = ({ children }: { children: React.ReactNode }) => (
   <div className="bg-dark-bg text-dark-bg-text">
     <div>{children}</div>


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

It's hacky, and I don't like it, but it works. Suppresses the "yada yada key yada" errors that react throws in the preview app. These errors are erroneous (irony!) because they're thrown for things that are static and not reactive.