### PR TITLE
fix(app-preview): Change how root path is determined for singular template

### DIFF
--- a/apps/preview/app/src/main.tsx
+++ b/apps/preview/app/src/main.tsx
@@ -33,6 +33,11 @@ const Layout = ({ children }: { children: React.ReactNode }) => (
 );
 
 function getCommonRoot(paths) {
+  if (paths.length === 1) {
+    const root = `${paths[0].split('/').slice(0, -1).join('/')}/`;
+    return root;
+  }
+
   const sortedPaths = paths.concat().sort();
   const [first] = sortedPaths;
   const last = sortedPaths[sortedPaths.length - 1];
@@ -41,6 +46,7 @@ function getCommonRoot(paths) {
   while (i < firstLength && first.charAt(i) === last.charAt(i)) {
     i += 1;
   }
+
   return first.substring(0, i);
 }
 
@@ -54,6 +60,7 @@ const parseName = (path: string) => {
 
 const modules = import.meta.glob('@/**/*.{jsx,tsx}', { eager: true });
 const sources = import.meta.glob('@/**/*.{jsx,tsx}', { as: 'raw', eager: true });
+
 const root = getCommonRoot(Object.keys(modules));
 
 const templates = (

--- a/packages/jsx-email/src/cli/commands/preview.ts
+++ b/packages/jsx-email/src/cli/commands/preview.ts
@@ -62,6 +62,7 @@ const getConfig = async (targetPath: string, argv: PreviewOptions) => {
   const config = {
     configFile: false,
     ...viteConfig,
+    define: { __JSX_EMAIL_TARGET_PATH__: JSON.stringify(targetPath) },
     resolve: {
       alias: {
         '@': targetPath,
@@ -78,7 +79,7 @@ const build = async (targetPath: string, argv: PreviewOptions) => {
   const { buildPath } = argv;
   const config = await getConfig(targetPath, argv);
 
-  delete config.define!['process.env'];
+  delete config.define['process.env'];
 
   await viteBuild({
     ...config,


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:


### Description

There is an issue when there is only one template present and how the path for the sidebar is handled. This should resolve that issue but selecting the root path in a different way for singular templates.
