### PR TITLE
fix(app-preview): use relative path replacement, fixes prod build

### DIFF
--- a/apps/preview/app/src/main.tsx
+++ b/apps/preview/app/src/main.tsx
@@ -41,12 +41,11 @@ const parseName = (path: string) => {
 };
 
 // @ts-expect-error
-const targetPath = __JSX_EMAIL_TARGET_PATH__;
+const relativePath = `${__JSX_EMAIL_RELATIVE_PATH__}/`;
 const modules = import.meta.glob('@/**/*.{jsx,tsx}', { eager: true });
 const sources = import.meta.glob('@/**/*.{jsx,tsx}', { as: 'raw', eager: true });
-const fileUrls = import.meta.glob('@/**/*.{jsx,tsx}', { as: 'url', eager: true });
-const pathLookup = Object.keys(fileUrls).reduce((acc, path) => {
-  acc[path] = fileUrls[path].replace(`/@fs${targetPath}/`, '');
+const pathLookup = Object.keys(modules).reduce((acc, path) => {
+  acc[path] = path.replace(relativePath, '');
   return acc;
 }, {});
 const sortedModules = Object.keys(modules)

--- a/packages/jsx-email/src/cli/commands/preview.ts
+++ b/packages/jsx-email/src/cli/commands/preview.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { resolve } from 'path';
+import { relative, resolve } from 'path';
 
 import chalk from 'chalk';
 import type { Infer } from 'superstruct';
@@ -59,10 +59,14 @@ export const command: CommandFn = async (argv: PreviewOptions, input) => {
 const getConfig = async (targetPath: string, argv: PreviewOptions) => {
   const { host = false, port = 55420 } = argv;
   const { viteConfig } = await import('./vite');
+  const realtivePath = relative(viteConfig.root!, targetPath);
   const config = {
     configFile: false,
     ...viteConfig,
-    define: { __JSX_EMAIL_TARGET_PATH__: JSON.stringify(targetPath), ...viteConfig.define },
+    define: {
+      __JSX_EMAIL_RELATIVE_PATH__: JSON.stringify(realtivePath),
+      ...viteConfig.define
+    },
     resolve: {
       alias: {
         '@': targetPath,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR resolves an issue with `email preview --build-path` where vite creates a production build for deployment. With using the `as: 'url'` method of `import.meta.glob` to get the file paths of the templates loaded in production, we're given back completely different values than running in dev. Many of those values are base64 octet data urls, which is useless for our needs. The clue to a fix was the relative path that vite was using. Calculating that ourselves and injecting it into the bundle gave us something that we could use in both prod and dev preview apps.