### PR TITLE
fix(jsx-email): normalize relative preview path for windows

### DIFF
--- a/packages/jsx-email/src/cli/commands/preview.ts
+++ b/packages/jsx-email/src/cli/commands/preview.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { relative, resolve } from 'path';
+import { relative, resolve, win32, posix } from 'path';
 
 import chalk from 'chalk';
 import type { Infer } from 'superstruct';
@@ -18,6 +18,7 @@ const PreviewOptionsStruct = object({
 type PreviewOptions = Infer<typeof PreviewOptionsStruct>;
 
 const { error, info } = console;
+const normalizePath = (filename: string) => filename.split(win32.sep).join(posix.sep);
 
 export const help = chalk`
 {blue email preview}
@@ -59,7 +60,8 @@ export const command: CommandFn = async (argv: PreviewOptions, input) => {
 const getConfig = async (targetPath: string, argv: PreviewOptions) => {
   const { host = false, port = 55420 } = argv;
   const { viteConfig } = await import('./vite');
-  const realtivePath = relative(viteConfig.root!, targetPath);
+  // FIXME: when we go for 2.0, add the trailing slash here and remove it from main.tsx
+  const realtivePath = normalizePath(relative(viteConfig.root!, targetPath));
   const config = {
     configFile: false,
     ...viteConfig,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Yay, Windows! The `relative` path for the preview app was backslash instead of forward slash on Winders, so we need to normalize that otherwise the file tree in preview looks bananas. 