### PR TITLE
fix(tailwind): shouldn't clobber `<head>` contents

### DIFF
--- a/apps/test/tests/.snapshots/smoke.spec.ts-Code-chromium.snap
+++ b/apps/test/tests/.snapshots/smoke.spec.ts-Code-chromium.snap
@@ -63,174 +63,172 @@
     </style>
   </head>
   <body class="bg-white my-auto mx-auto font-sans">
-    <div>
-      <table
-        align="center"
-        width="100%"
-        class="border-separate border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[20px] w-[465px]"
-        role="presentation"
-        cellspacing="0"
-        cellpadding="0"
-        border="0"
-        style="max-width:37.5em"
-      >
-        <tbody>
-          <tr style="width:100%">
-            <td>
-              <div>
-                <pre
-                  class="shiki nord"
-                  style="background-color:#2e3440ff;color:#d8dee9ff"
-                  tabindex="0"
-                >
-                  <code>
-                    <span class="line">
+    <table
+      align="center"
+      width="100%"
+      class="border-separate border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[20px] w-[465px]"
+      role="presentation"
+      cellspacing="0"
+      cellpadding="0"
+      border="0"
+      style="max-width:37.5em"
+    >
+      <tbody>
+        <tr style="width:100%">
+          <td>
+            <div>
+              <pre
+                class="shiki nord"
+                style="background-color:#2e3440ff;color:#d8dee9ff"
+                tabindex="0"
+              >
+                <code>
+                  <span class="line">
+                  </span>
+                  <span class="line">
+                    <span style="color:#81A1C1">
+                      import
                     </span>
-                    <span class="line">
-                      <span style="color:#81A1C1">
-                        import
-                      </span>
-                      <span style="color:#ECEFF4">
-                        {
-                      </span>
-                      <span style="color:#8FBCBB">
-                        batman
-                      </span>
-                      <span style="color:#ECEFF4">
-                        }
-                      </span>
-                      <span style="color:#81A1C1">
-                        from
-                      </span>
-                      <span style="color:#ECEFF4">
-                        '
-                      </span>
-                      <span style="color:#A3BE8C">
-                        superheros
-                      </span>
-                      <span style="color:#ECEFF4">
-                        '
-                      </span>
-                      <span style="color:#81A1C1">
-                        ;
-                      </span>
+                    <span style="color:#ECEFF4">
+                      {
                     </span>
-                    <span class="line">
-                      <span style="color:#81A1C1">
-                        import
-                      </span>
-                      <span style="color:#ECEFF4">
-                        {
-                      </span>
-                      <span style="color:#8FBCBB">
-                        joker
-                      </span>
-                      <span style="color:#ECEFF4">
-                        }
-                      </span>
-                      <span style="color:#81A1C1">
-                        from
-                      </span>
-                      <span style="color:#ECEFF4">
-                        '
-                      </span>
-                      <span style="color:#A3BE8C">
-                        villains
-                      </span>
-                      <span style="color:#ECEFF4">
-                        '
-                      </span>
-                      <span style="color:#81A1C1">
-                        ;
-                      </span>
+                    <span style="color:#8FBCBB">
+                      batman
                     </span>
-                    <span class="line">
+                    <span style="color:#ECEFF4">
+                      }
                     </span>
-                    <span class="line">
-                      <span style="color:#81A1C1">
-                        const
-                      </span>
-                      <span style="color:#D8DEE9">
-                        henchmen
-                      </span>
-                      <span style="color:#81A1C1">
-                        =
-                      </span>
-                      <span style="color:#D8DEE9">
-                        joker
-                      </span>
-                      <span style="color:#ECEFF4">
-                        .
-                      </span>
-                      <span style="color:#88C0D0">
-                        help
-                      </span>
-                      <span style="color:#D8DEE9FF">
-                        ()
-                      </span>
-                      <span style="color:#81A1C1">
-                        ;
-                      </span>
+                    <span style="color:#81A1C1">
+                      from
                     </span>
-                    <span class="line">
+                    <span style="color:#ECEFF4">
+                      '
                     </span>
-                    <span class="line">
-                      <span style="color:#D8DEE9">
-                        batman
-                      </span>
-                      <span style="color:#ECEFF4">
-                        .
-                      </span>
-                      <span style="color:#88C0D0">
-                        fight
-                      </span>
-                      <span style="color:#D8DEE9FF">
-                        (
-                      </span>
-                      <span style="color:#D8DEE9">
-                        henchmen
-                      </span>
-                      <span style="color:#D8DEE9FF">
-                        )
-                      </span>
-                      <span style="color:#81A1C1">
-                        ;
-                      </span>
+                    <span style="color:#A3BE8C">
+                      superheros
                     </span>
-                    <span class="line">
-                      <span style="color:#D8DEE9">
-                        batman
-                      </span>
-                      <span style="color:#ECEFF4">
-                        .
-                      </span>
-                      <span style="color:#88C0D0">
-                        arrest
-                      </span>
-                      <span style="color:#D8DEE9FF">
-                        (
-                      </span>
-                      <span style="color:#D8DEE9">
-                        joker
-                      </span>
-                      <span style="color:#D8DEE9FF">
-                        )
-                      </span>
-                      <span style="color:#81A1C1">
-                        ;
-                      </span>
+                    <span style="color:#ECEFF4">
+                      '
                     </span>
-                    <span class="line">
-                      <span style="color:#D8DEE9FF">
-                      </span>
+                    <span style="color:#81A1C1">
+                      ;
                     </span>
-                  </code>
-                </pre>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+                  </span>
+                  <span class="line">
+                    <span style="color:#81A1C1">
+                      import
+                    </span>
+                    <span style="color:#ECEFF4">
+                      {
+                    </span>
+                    <span style="color:#8FBCBB">
+                      joker
+                    </span>
+                    <span style="color:#ECEFF4">
+                      }
+                    </span>
+                    <span style="color:#81A1C1">
+                      from
+                    </span>
+                    <span style="color:#ECEFF4">
+                      '
+                    </span>
+                    <span style="color:#A3BE8C">
+                      villains
+                    </span>
+                    <span style="color:#ECEFF4">
+                      '
+                    </span>
+                    <span style="color:#81A1C1">
+                      ;
+                    </span>
+                  </span>
+                  <span class="line">
+                  </span>
+                  <span class="line">
+                    <span style="color:#81A1C1">
+                      const
+                    </span>
+                    <span style="color:#D8DEE9">
+                      henchmen
+                    </span>
+                    <span style="color:#81A1C1">
+                      =
+                    </span>
+                    <span style="color:#D8DEE9">
+                      joker
+                    </span>
+                    <span style="color:#ECEFF4">
+                      .
+                    </span>
+                    <span style="color:#88C0D0">
+                      help
+                    </span>
+                    <span style="color:#D8DEE9FF">
+                      ()
+                    </span>
+                    <span style="color:#81A1C1">
+                      ;
+                    </span>
+                  </span>
+                  <span class="line">
+                  </span>
+                  <span class="line">
+                    <span style="color:#D8DEE9">
+                      batman
+                    </span>
+                    <span style="color:#ECEFF4">
+                      .
+                    </span>
+                    <span style="color:#88C0D0">
+                      fight
+                    </span>
+                    <span style="color:#D8DEE9FF">
+                      (
+                    </span>
+                    <span style="color:#D8DEE9">
+                      henchmen
+                    </span>
+                    <span style="color:#D8DEE9FF">
+                      )
+                    </span>
+                    <span style="color:#81A1C1">
+                      ;
+                    </span>
+                  </span>
+                  <span class="line">
+                    <span style="color:#D8DEE9">
+                      batman
+                    </span>
+                    <span style="color:#ECEFF4">
+                      .
+                    </span>
+                    <span style="color:#88C0D0">
+                      arrest
+                    </span>
+                    <span style="color:#D8DEE9FF">
+                      (
+                    </span>
+                    <span style="color:#D8DEE9">
+                      joker
+                    </span>
+                    <span style="color:#D8DEE9FF">
+                      )
+                    </span>
+                    <span style="color:#81A1C1">
+                      ;
+                    </span>
+                  </span>
+                  <span class="line">
+                    <span style="color:#D8DEE9FF">
+                    </span>
+                  </span>
+                </code>
+              </pre>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </body>
 </html>

--- a/apps/test/tests/.snapshots/smoke.spec.ts-Tailwind-chromium.snap
+++ b/apps/test/tests/.snapshots/smoke.spec.ts-Tailwind-chromium.snap
@@ -31,22 +31,20 @@
     </style>
   </head>
   <body>
-    <div>
-      <a
-        href="https://example.com"
-        class="px-3 py-2 font-medium leading-4 text-white bg-brand"
-        style="display:inline-block;line-height:100%;max-width:100%;text-decoration:none"
-      >
-        <span>
-          <!--[if mso]><i style="mso-font-width:-100%;" hidden>&nbsp;</i><![endif]-->
-        </span>
-        <span style="display:inline-block;line-height:120%;max-width:100%;mso-padding-alt:0px;mso-text-raise:0">
-          Click me
-        </span>
-        <span>
-          <!--[if mso]><i style="mso-font-width:-100%" hidden>&nbsp;</i><![endif]-->
-        </span>
-      </a>
-    </div>
+    <a
+      href="https://example.com"
+      class="px-3 py-2 font-medium leading-4 text-white bg-brand"
+      style="display:inline-block;line-height:100%;max-width:100%;text-decoration:none"
+    >
+      <span>
+        <!--[if mso]><i style="mso-font-width:-100%;" hidden>&nbsp;</i><![endif]-->
+      </span>
+      <span style="display:inline-block;line-height:120%;max-width:100%;mso-padding-alt:0px;mso-text-raise:0">
+        Click me
+      </span>
+      <span>
+        <!--[if mso]><i style="mso-font-width:-100%" hidden>&nbsp;</i><![endif]-->
+      </span>
+    </a>
   </body>
 </html>

--- a/packages/jsx-email/src/components/tailwind/tailwind.tsx
+++ b/packages/jsx-email/src/components/tailwind/tailwind.tsx
@@ -92,7 +92,7 @@ const render = async ({
 const Renderer = (props: React.PropsWithChildren<TailwindProps>) => {
   const html = useData(props, () => render(props));
 
-  return <div {...debugProps} dangerouslySetInnerHTML={{ __html: html }} />;
+  return <head {...debugProps} dangerouslySetInnerHTML={{ __html: html }} />;
 };
 
 export const Tailwind = ({ children, ...props }: React.PropsWithChildren<TailwindProps>) => (

--- a/packages/jsx-email/test/render/.snapshots/render.test.tsx.snap
+++ b/packages/jsx-email/test/render/.snapshots/render.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`render > renders the vercel demo template 1`] = `
 .font-semibold{font-weight:600;}
 .leading-\\\\[24px\\\\]{line-height:24px;}
 .font-sans{font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,\\"Segoe UI\\",Roboto,\\"Helvetica Neue\\",Arial,\\"Noto Sans\\",sans-serif,\\"Apple Color Emoji\\",\\"Segoe UI Emoji\\",\\"Segoe UI Symbol\\",\\"Noto Color Emoji\\";}
-.no-underline{text-decoration:none;}</style></head><body class=\\"bg-white my-auto mx-auto font-sans\\"><div><table align=\\"center\\" width=\\"100%\\" class=\\"border-separate border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[20px] w-[465px]\\" role=\\"presentation\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" style=\\"max-width:37.5em\\"><tbody><tr style=\\"width:100%\\"><td><table align=\\"center\\" width=\\"100%\\" class=\\"mt-[32px]\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\"><tbody><tr><td><img class=\\"my-0 mx-auto\\" alt=\\"Vercel\\" src=\\"vercel-logo.png\\" width=\\"40\\" height=\\"37\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td></tr></tbody></table><h1 class=\\"text-black text-[24px] font-normal text-center p-0 my-[30px] mx-0\\" style>Join <strong></strong> on <strong>Vercel</strong></h1><p class=\\"text-black text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">Hello,</p><p class=\\"text-black text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\"><strong></strong> (<a href=\\"mailto:\\" class=\\"text-blue-600 no-underline\\" style=\\"color:#067df7;text-decoration:none\\"></a>) has invited you to the <strong></strong> team on <strong>Vercel</strong>.</p><table align=\\"center\\" width=\\"100%\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\"><tbody><tr><td><table align=\\"center\\" width=\\"100%\\" role=\\"presentation\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\"><tbody style=\\"width:100%\\"><tr style=\\"width:100%\\"><td align=\\"right\\"><img class=\\"rounded-full\\" src width=\\"64\\" height=\\"64\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td><td align=\\"center\\"><img alt=\\"invited you to\\" src=\\"vercel-arrow.png\\" width=\\"12\\" height=\\"9\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td><td align=\\"left\\"><img class=\\"rounded-full\\" src width=\\"64\\" height=\\"64\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td></tr></tbody></table></td></tr></tbody></table><table align=\\"center\\" width=\\"100%\\" class=\\"text-center mt-[32px] mb-[32px]\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\"><tbody><tr><td><a class=\\"bg-[#000000] rounded text-white text-[12px] px-5 py-3 font-semibold no-underline text-center\\" href style=\\"display:inline-block;line-height:100%;max-width:100%;text-decoration:none\\"><span><!--[if mso]><i style=\\"mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"display:inline-block;line-height:120%;max-width:100%;mso-padding-alt:0px;mso-text-raise:0\\">Join the team</span><span><!--[if mso]><i style=\\"mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a></td></tr></tbody></table><p class=\\"text-black !text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">or copy and paste this URL into your browser: <a href class=\\"text-blue-600 no-underline\\" style=\\"color:#067df7;text-decoration:none\\"></a></p><hr class=\\"border border-solid border-[#eaeaea] my-[26px] mx-0 w-full\\" style=\\"border:none;border-top:1px solid #eaeaea;width:100%\\"><p class=\\"text-[#666666] !text-[12px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">This invitation was intended for <span class=\\"text-black\\"> </span>.This invite was sent from <span class=\\"text-black\\"></span> located in <span class=\\"text-black\\"></span>. If you were not expecting this invitation, you can ignore this email. If you are concerned about your account's safety, please reply to this email to get in touch with us.</p></td></tr></tbody></table></div></body></html>"
+.no-underline{text-decoration:none;}</style></head><body class=\\"bg-white my-auto mx-auto font-sans\\"><table align=\\"center\\" width=\\"100%\\" class=\\"border-separate border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[20px] w-[465px]\\" role=\\"presentation\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" style=\\"max-width:37.5em\\"><tbody><tr style=\\"width:100%\\"><td><table align=\\"center\\" width=\\"100%\\" class=\\"mt-[32px]\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\"><tbody><tr><td><img class=\\"my-0 mx-auto\\" alt=\\"Vercel\\" src=\\"vercel-logo.png\\" width=\\"40\\" height=\\"37\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td></tr></tbody></table><h1 class=\\"text-black text-[24px] font-normal text-center p-0 my-[30px] mx-0\\" style>Join <strong></strong> on <strong>Vercel</strong></h1><p class=\\"text-black text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">Hello,</p><p class=\\"text-black text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\"><strong></strong> (<a href=\\"mailto:\\" class=\\"text-blue-600 no-underline\\" style=\\"color:#067df7;text-decoration:none\\"></a>) has invited you to the <strong></strong> team on <strong>Vercel</strong>.</p><table align=\\"center\\" width=\\"100%\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\"><tbody><tr><td><table align=\\"center\\" width=\\"100%\\" role=\\"presentation\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\"><tbody style=\\"width:100%\\"><tr style=\\"width:100%\\"><td align=\\"right\\"><img class=\\"rounded-full\\" src width=\\"64\\" height=\\"64\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td><td align=\\"center\\"><img alt=\\"invited you to\\" src=\\"vercel-arrow.png\\" width=\\"12\\" height=\\"9\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td><td align=\\"left\\"><img class=\\"rounded-full\\" src width=\\"64\\" height=\\"64\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td></tr></tbody></table></td></tr></tbody></table><table align=\\"center\\" width=\\"100%\\" class=\\"text-center mt-[32px] mb-[32px]\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\"><tbody><tr><td><a class=\\"bg-[#000000] rounded text-white text-[12px] px-5 py-3 font-semibold no-underline text-center\\" href style=\\"display:inline-block;line-height:100%;max-width:100%;text-decoration:none\\"><span><!--[if mso]><i style=\\"mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"display:inline-block;line-height:120%;max-width:100%;mso-padding-alt:0px;mso-text-raise:0\\">Join the team</span><span><!--[if mso]><i style=\\"mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a></td></tr></tbody></table><p class=\\"text-black !text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">or copy and paste this URL into your browser: <a href class=\\"text-blue-600 no-underline\\" style=\\"color:#067df7;text-decoration:none\\"></a></p><hr class=\\"border border-solid border-[#eaeaea] my-[26px] mx-0 w-full\\" style=\\"border:none;border-top:1px solid #eaeaea;width:100%\\"><p class=\\"text-[#666666] !text-[12px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">This invitation was intended for <span class=\\"text-black\\"> </span>.This invite was sent from <span class=\\"text-black\\"></span> located in <span class=\\"text-black\\"></span>. If you were not expecting this invitation, you can ignore this email. If you are concerned about your account's safety, please reply to this email to get in touch with us.</p></td></tr></tbody></table></body></html>"
 `;
 
 exports[`render > renders the vercel demo template 2`] = `
@@ -356,53 +356,51 @@ exports[`render > renders the vercel demo template 2`] = `
   </head>
 
   <body class=\\"bg-white my-auto mx-auto font-sans\\">
-    <div>
-      <table align=\\"center\\" width=\\"100%\\" class=\\"border-separate border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[20px] w-[465px]\\" role=\\"presentation\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" style=\\"max-width:37.5em\\">
-        <tbody>
-          <tr style=\\"width:100%\\">
-            <td>
-              <table align=\\"center\\" width=\\"100%\\" class=\\"mt-[32px]\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\">
-                <tbody>
-                  <tr>
-                    <td><img class=\\"my-0 mx-auto\\" alt=\\"Vercel\\" src=\\"vercel-logo.png\\" width=\\"40\\" height=\\"37\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <h1 class=\\"text-black text-[24px] font-normal text-center p-0 my-[30px] mx-0\\" style>Join <strong></strong> on <strong>Vercel</strong></h1>
-              <p class=\\"text-black text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">Hello,</p>
-              <p class=\\"text-black text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\"><strong></strong> (<a href=\\"mailto:\\" class=\\"text-blue-600 no-underline\\" style=\\"color:#067df7;text-decoration:none\\"></a>) has invited you to the <strong></strong> team on <strong>Vercel</strong>.</p>
-              <table align=\\"center\\" width=\\"100%\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\">
-                <tbody>
-                  <tr>
-                    <td>
-                      <table align=\\"center\\" width=\\"100%\\" role=\\"presentation\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\">
-                        <tbody style=\\"width:100%\\">
-                          <tr style=\\"width:100%\\">
-                            <td align=\\"right\\"><img class=\\"rounded-full\\" src width=\\"64\\" height=\\"64\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td>
-                            <td align=\\"center\\"><img alt=\\"invited you to\\" src=\\"vercel-arrow.png\\" width=\\"12\\" height=\\"9\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td>
-                            <td align=\\"left\\"><img class=\\"rounded-full\\" src width=\\"64\\" height=\\"64\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              <table align=\\"center\\" width=\\"100%\\" class=\\"text-center mt-[32px] mb-[32px]\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\">
-                <tbody>
-                  <tr>
-                    <td><a class=\\"bg-[#000000] rounded text-white text-[12px] px-5 py-3 font-semibold no-underline text-center\\" href style=\\"display:inline-block;line-height:100%;max-width:100%;text-decoration:none\\"><span><!--[if mso]><i style=\\"mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"display:inline-block;line-height:120%;max-width:100%;mso-padding-alt:0px;mso-text-raise:0\\">Join the team</span><span><!--[if mso]><i style=\\"mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a></td>
-                  </tr>
-                </tbody>
-              </table>
-              <p class=\\"text-black !text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">or copy and paste this URL into your browser: <a href class=\\"text-blue-600 no-underline\\" style=\\"color:#067df7;text-decoration:none\\"></a></p>
-              <hr class=\\"border border-solid border-[#eaeaea] my-[26px] mx-0 w-full\\" style=\\"border:none;border-top:1px solid #eaeaea;width:100%\\">
-              <p class=\\"text-[#666666] !text-[12px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">This invitation was intended for <span class=\\"text-black\\"> </span>.This invite was sent from <span class=\\"text-black\\"></span> located in <span class=\\"text-black\\"></span>. If you were not expecting this invitation, you can ignore this email. If you are concerned about your account's safety, please reply to this email to get in touch with us.</p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <table align=\\"center\\" width=\\"100%\\" class=\\"border-separate border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[20px] w-[465px]\\" role=\\"presentation\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" style=\\"max-width:37.5em\\">
+      <tbody>
+        <tr style=\\"width:100%\\">
+          <td>
+            <table align=\\"center\\" width=\\"100%\\" class=\\"mt-[32px]\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\">
+              <tbody>
+                <tr>
+                  <td><img class=\\"my-0 mx-auto\\" alt=\\"Vercel\\" src=\\"vercel-logo.png\\" width=\\"40\\" height=\\"37\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td>
+                </tr>
+              </tbody>
+            </table>
+            <h1 class=\\"text-black text-[24px] font-normal text-center p-0 my-[30px] mx-0\\" style>Join <strong></strong> on <strong>Vercel</strong></h1>
+            <p class=\\"text-black text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">Hello,</p>
+            <p class=\\"text-black text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\"><strong></strong> (<a href=\\"mailto:\\" class=\\"text-blue-600 no-underline\\" style=\\"color:#067df7;text-decoration:none\\"></a>) has invited you to the <strong></strong> team on <strong>Vercel</strong>.</p>
+            <table align=\\"center\\" width=\\"100%\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\">
+              <tbody>
+                <tr>
+                  <td>
+                    <table align=\\"center\\" width=\\"100%\\" role=\\"presentation\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\">
+                      <tbody style=\\"width:100%\\">
+                        <tr style=\\"width:100%\\">
+                          <td align=\\"right\\"><img class=\\"rounded-full\\" src width=\\"64\\" height=\\"64\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td>
+                          <td align=\\"center\\"><img alt=\\"invited you to\\" src=\\"vercel-arrow.png\\" width=\\"12\\" height=\\"9\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td>
+                          <td align=\\"left\\"><img class=\\"rounded-full\\" src width=\\"64\\" height=\\"64\\" style=\\"border:none;display:block;outline:none;text-decoration:none\\"></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table align=\\"center\\" width=\\"100%\\" class=\\"text-center mt-[32px] mb-[32px]\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\">
+              <tbody>
+                <tr>
+                  <td><a class=\\"bg-[#000000] rounded text-white text-[12px] px-5 py-3 font-semibold no-underline text-center\\" href style=\\"display:inline-block;line-height:100%;max-width:100%;text-decoration:none\\"><span><!--[if mso]><i style=\\"mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><span style=\\"display:inline-block;line-height:120%;max-width:100%;mso-padding-alt:0px;mso-text-raise:0\\">Join the team</span><span><!--[if mso]><i style=\\"mso-font-width:-100%\\" hidden>&nbsp;</i><![endif]--></span></a></td>
+                </tr>
+              </tbody>
+            </table>
+            <p class=\\"text-black !text-[14px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">or copy and paste this URL into your browser: <a href class=\\"text-blue-600 no-underline\\" style=\\"color:#067df7;text-decoration:none\\"></a></p>
+            <hr class=\\"border border-solid border-[#eaeaea] my-[26px] mx-0 w-full\\" style=\\"border:none;border-top:1px solid #eaeaea;width:100%\\">
+            <p class=\\"text-[#666666] !text-[12px] leading-[24px]\\" style=\\"font-size:14px;line-height:24px;margin:16px 0\\">This invitation was intended for <span class=\\"text-black\\"> </span>.This invite was sent from <span class=\\"text-black\\"></span> located in <span class=\\"text-black\\"></span>. If you were not expecting this invitation, you can ignore this email. If you are concerned about your account's safety, please reply to this email to get in touch with us.</p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </body>
 
 </html>"

--- a/packages/jsx-email/test/tailwind/.snapshots/tailwind-head.test.tsx.snap
+++ b/packages/jsx-email/test/tailwind/.snapshots/tailwind-head.test.tsx.snap
@@ -1,0 +1,20 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Tailwind + Head > should not clobber <Head> content 1`] = `"<html lang=\\"en\\" dir=\\"ltr\\"><head><head><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"/><title>test title</title></head><style tailwind>/* layer: preflights */</style></head></html>"`;
+
+exports[`Tailwind + Head > should not clobber <Head> content 2`] = `
+"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\">
+<html lang=\\"en\\" dir=\\"ltr\\">
+
+  <head>
+    <meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\">
+    <title>test title</title>
+    <style tailwind>
+      /* layer: preflights */
+    </style>
+  </head>
+
+  <body></body>
+
+</html>"
+`;

--- a/packages/jsx-email/test/tailwind/.snapshots/tailwind.test.tsx.snap
+++ b/packages/jsx-email/test/tailwind/.snapshots/tailwind.test.tsx.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<Tailwind> component > should preserve mso styles 1`] = `
-"<div><html lang=\\"en\\" dir=\\"ltr\\"><head><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"/></head><span><!--[if mso]><i style=\\"letter-spacing: 10px;mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><div class=\\"bg-white sm:bg-red-50 sm:text-sm md:text-lg custom-class\\"></div></html><style tailwind>/* layer: preflights */
+"<head><html lang=\\"en\\" dir=\\"ltr\\"><head><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"/></head><span><!--[if mso]><i style=\\"letter-spacing: 10px;mso-font-width:-100%;\\" hidden>&nbsp;</i><![endif]--></span><div class=\\"bg-white sm:bg-red-50 sm:text-sm md:text-lg custom-class\\"></div></html><style tailwind>/* layer: preflights */
 /* layer: default */
 .bg-white{background-color:rgb(255,255,255);}
 @media (min-width: 640px){
@@ -12,11 +12,11 @@ exports[`<Tailwind> component > should preserve mso styles 1`] = `
 }
 @media (min-width: 768px){
 .md\\\\:text-lg{font-size:1.125rem;line-height:1.75rem;}
-}</style></div>"
+}</style></head>"
 `;
 
 exports[`<Tailwind> component > should recognize custom resopnsive screen 1`] = `
-"<div><html lang=\\"en\\" dir=\\"ltr\\"><head><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"/></head><div class=\\"xl:bg-green-500\\">Test</div><div class=\\"2xl:bg-blue-500\\">Test</div></html><style tailwind>/* layer: preflights */
+"<head><html lang=\\"en\\" dir=\\"ltr\\"><head><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"/></head><div class=\\"xl:bg-green-500\\">Test</div><div class=\\"2xl:bg-blue-500\\">Test</div></html><style tailwind>/* layer: preflights */
 /* layer: default */
 @media (min-width: 1280px){
 .xl\\\\:bg-green-500{background-color:rgb(34,197,94);}
@@ -31,94 +31,145 @@ exports[`<Tailwind> component > should recognize custom resopnsive screen 1`] = 
 .\\\\32 xl\\\\:bg-blue-500{background-color:rgb(59,130,246);
 }
 }
-}</style></div>"
+}</style></head>"
+`;
+
+exports[`<Tailwind> component > should work with calc() with + sign 1`] = `
+"<head><div class=\\"max-h-[calc(50px+3rem)] bg-red-100\\"><div class=\\"h-[200px]\\">something tall</div></div><style tailwind>/* layer: preflights */
+/* layer: default */
+.h-\\\\[200px\\\\]{height:200px;}
+.max-h-\\\\[calc\\\\(50px\\\\+3rem\\\\)\\\\]{max-height:calc(50px + 3rem);}
+.bg-red-100{background-color:rgb(254,226,226);}</style></head>"
 `;
 
 exports[`Custom theme config > should be able to use custom border radius 1`] = `
-"<div><div class=\\"rounded-4xl\\"></div><style tailwind>/* layer: preflights */
+"<head><div class=\\"rounded-4xl\\"></div><style tailwind>/* layer: preflights */
 /* layer: default */
-.rounded-4xl{border-radius:2rem;}</style></div>"
+.rounded-4xl{border-radius:2rem;}</style></head>"
 `;
 
 exports[`Custom theme config > should be able to use custom colors 1`] = `
-"<div><div class=\\"text-custom bg-custom\\"></div><style tailwind>/* layer: preflights */
+"<head><div class=\\"text-custom bg-custom\\"></div><style tailwind>/* layer: preflights */
 /* layer: default */
 .bg-custom{background-color:rgb(31,182,255);}
-.text-custom{color:rgb(31,182,255);}</style></div>"
+.text-custom{color:rgb(31,182,255);}</style></head>"
 `;
 
 exports[`Custom theme config > should be able to use custom fonts 1`] = `
-"<div><div class=\\"font-sans\\"></div><div class=\\"font-serif\\"></div><style tailwind>/* layer: preflights */
+"<head><div class=\\"font-sans\\"></div><div class=\\"font-serif\\"></div><style tailwind>/* layer: preflights */
 /* layer: default */
 .font-sans{font-family:Graphik,sans-serif;}
-.font-serif{font-family:Merriweather,serif;}</style></div>"
+.font-serif{font-family:Merriweather,serif;}</style></head>"
 `;
 
 exports[`Custom theme config > should be able to use custom spacing 1`] = `
-"<div><div class=\\"m-8xl\\"></div><style tailwind>/* layer: preflights */
+"<head><div class=\\"m-8xl\\"></div><style tailwind>/* layer: preflights */
 /* layer: default */
-.m-8xl{margin:96rem;}</style></div>"
+.m-8xl{margin:96rem;}</style></head>"
 `;
 
 exports[`Custom theme config > should be able to use custom text alignment 1`] = `
-"<div><div class=\\"text-justify\\"></div><style tailwind>/* layer: preflights */
+"<head><div class=\\"text-justify\\"></div><style tailwind>/* layer: preflights */
 /* layer: default */
-.text-justify{text-align:justify;}</style></div>"
+.text-justify{text-align:justify;}</style></head>"
 `;
 
 exports[`Production mode > should generate class names with a prefix 1`] = `
-"<div><html lang=\\"en\\" dir=\\"ltr\\"><div class=\\"je-5wyw0k\\"></div></html><style tailwind>/* layer: preflights */
+"<head><html lang=\\"en\\" dir=\\"ltr\\"><div class=\\"je-5wyw0k\\"></div></html><style tailwind>/* layer: preflights */
 /* layer: shortcuts */
-.je-5wyw0k{background-color:rgb(254,226,226);font-size:0.875rem;line-height:1.25rem;}</style></div>"
+.je-5wyw0k{background-color:rgb(254,226,226);font-size:0.875rem;line-height:1.25rem;}</style></head>"
 `;
 
 exports[`Responsive styles > should add css to <head/> 1`] = `
-"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><html><head><style tailwind>/* layer: preflights */
-/* layer: default */
-.bg-red-200{background-color:rgb(254,202,202);}
-@media (min-width: 640px){
-.sm\\\\:bg-red-300{background-color:rgb(252,165,165);}
-@media (min-width: 640px){
-.sm\\\\:bg-red-300{background-color:rgb(252,165,165);}}
-}
-@media (min-width: 768px){
-.md\\\\:bg-red-400{background-color:rgb(248,113,113);}
-@media (min-width: 768px){
-.md\\\\:bg-red-400{background-color:rgb(248,113,113);}}
-}
-@media (min-width: 1024px){
-.lg\\\\:bg-red-500{background-color:rgb(239,68,68);}
-@media (min-width: 1024px){
-.lg\\\\:bg-red-500{background-color:rgb(239,68,68);}}
-}</style></head><body><div><div class=\\"bg-red-200 sm:bg-red-300 md:bg-red-400 lg:bg-red-500\\"></div></div></body></html>"
+"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\">
+<html>
+
+  <head>
+    <style tailwind>
+      /* layer: preflights */
+      /* layer: default */
+      .bg-red-200 {
+        background-color: rgb(254, 202, 202);
+      }
+
+      @media (min-width: 640px) {
+        .sm\\\\:bg-red-300 {
+          background-color: rgb(252, 165, 165);
+        }
+
+        @media (min-width: 640px) {
+          .sm\\\\:bg-red-300 {
+            background-color: rgb(252, 165, 165);
+          }
+        }
+      }
+
+      @media (min-width: 768px) {
+        .md\\\\:bg-red-400 {
+          background-color: rgb(248, 113, 113);
+        }
+
+        @media (min-width: 768px) {
+          .md\\\\:bg-red-400 {
+            background-color: rgb(248, 113, 113);
+          }
+        }
+      }
+
+      @media (min-width: 1024px) {
+        .lg\\\\:bg-red-500 {
+          background-color: rgb(239, 68, 68);
+        }
+
+        @media (min-width: 1024px) {
+          .lg\\\\:bg-red-500 {
+            background-color: rgb(239, 68, 68);
+          }
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class=\\"bg-red-200 sm:bg-red-300 md:bg-red-400 lg:bg-red-500\\"></div>
+  </body>
+
+</html>"
 `;
 
 exports[`Responsive styles > should persist exsisting <head/> elements 1`] = `
-"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><html><head><style></style><style tailwind>/* layer: preflights */
+"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><html><head><style></style><link><style tailwind>/* layer: preflights */
 /* layer: default */
 .bg-red-200{background-color:rgb(254,202,202);}
 @media (min-width: 640px){
 .sm\\\\:bg-red-500{background-color:rgb(239,68,68);}
 @media (min-width: 640px){
 .sm\\\\:bg-red-500{background-color:rgb(239,68,68);}}
-}</style></head><body><div><link><div class=\\"bg-red-200 sm:bg-red-500\\"></div></div></body></html>"
+}</style></head><body><div class=\\"bg-red-200 sm:bg-red-500\\"></div></body></html>"
+`;
+
+exports[`Tailwind component > Inline styles > should render children with inline Tailwind styles 1`] = `
+"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><html><head><style tailwind>/* layer: preflights */
+/* layer: default */
+.bg-white{background-color:rgb(255,255,255);}
+.text-sm{font-size:0.875rem;line-height:1.25rem;}</style></head><body><div class=\\"bg-white text-sm\\"></div></body></html>"
 `;
 
 exports[`Tailwind component > should be able to use background image 1`] = `
-"<div><div class=\\"bg-[url(https://example.com/image.png)]\\"></div><style tailwind>/* layer: preflights */
+"<head><div class=\\"bg-[url(https://example.com/image.png)]\\"></div><style tailwind>/* layer: preflights */
 /* layer: default */
-.bg-\\\\[url\\\\(https\\\\:\\\\/\\\\/example\\\\.com\\\\/image\\\\.png\\\\)\\\\]{background-image:url(https://example.com/image.png);}</style></div>"
+.bg-\\\\[url\\\\(https\\\\:\\\\/\\\\/example\\\\.com\\\\/image\\\\.png\\\\)\\\\]{background-image:url(https://example.com/image.png);}</style></head>"
 `;
 
 exports[`Tailwind component > should preserve component inline styles with Tailwind styles 1`] = `
-"<div><hr class=\\"!w-12\\" style=\\"border:none;border-top:1px solid #eaeaea;width:100%\\"/><style tailwind>/* layer: preflights */
+"<head><hr class=\\"!w-12\\" style=\\"border:none;border-top:1px solid #eaeaea;width:100%\\"/><style tailwind>/* layer: preflights */
 /* layer: default */
-.\\\\!w-12{width:3rem !important;}</style></div>"
+.\\\\!w-12{width:3rem !important;}</style></head>"
 `;
 
 exports[`Tailwind component > should preserve inline styles with Tailwind classes 1`] = `
-"<div><div style=\\"background-color:red;font-size:12px\\" class=\\"bg-black text-[16px]\\"></div><style tailwind>/* layer: preflights */
+"<head><div style=\\"background-color:red;font-size:12px\\" class=\\"bg-black text-[16px]\\"></div><style tailwind>/* layer: preflights */
 /* layer: default */
 .bg-black{background-color:rgb(0,0,0);}
-.text-\\\\[16px\\\\]{font-size:16px;}</style></div>"
+.text-\\\\[16px\\\\]{font-size:16px;}</style></head>"
 `;

--- a/packages/jsx-email/test/tailwind/tailwind-head.test.tsx
+++ b/packages/jsx-email/test/tailwind/tailwind-head.test.tsx
@@ -1,0 +1,26 @@
+// @ts-ignore
+import React from 'react';
+
+import { jsxToString, render, Head, Html, Tailwind } from '../../dist';
+
+const Component = () => (
+  <Html>
+    <Tailwind>
+      <Head>
+        <title>test title</title>
+      </Head>
+    </Tailwind>
+  </Html>
+);
+
+describe('Tailwind + Head', async () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  test('should not clobber <Head> content', async () => {
+    expect(await jsxToString(<Component />)).toMatchSnapshot();
+    expect(await render(<Component />, { pretty: true })).toMatchSnapshot();
+  });
+});

--- a/packages/jsx-email/test/tailwind/tailwind.test.tsx
+++ b/packages/jsx-email/test/tailwind/tailwind.test.tsx
@@ -24,6 +24,14 @@ describe('Tailwind component', async () => {
       );
 
       expect(actualOutput).not.toBeNull();
+
+      const renderOutput = await render(
+        <Tailwind>
+          <div className="bg-white text-sm" />
+        </Tailwind>
+      );
+
+      expect(renderOutput).toMatchSnapshot();
     });
   });
 
@@ -69,7 +77,8 @@ describe('Responsive styles', async () => {
             <div className="bg-red-200 sm:bg-red-300 md:bg-red-400 lg:bg-red-500" />
           </body>
         </html>
-      </Tailwind>
+      </Tailwind>,
+      { pretty: true }
     );
     expect(actualOutput).toMatchSnapshot();
   });
@@ -248,15 +257,7 @@ describe('<Tailwind> component', async () => {
       </Tailwind>
     );
 
-    expect(actualOutput).toMatchInlineSnapshot(
-      `
-      "<div><div class=\\"max-h-[calc(50px+3rem)] bg-red-100\\"><div class=\\"h-[200px]\\">something tall</div></div><style tailwind>/* layer: preflights */
-      /* layer: default */
-      .h-\\\\[200px\\\\]{height:200px;}
-      .max-h-\\\\[calc\\\\(50px\\\\+3rem\\\\)\\\\]{max-height:calc(50px + 3rem);}
-      .bg-red-100{background-color:rgb(254,226,226);}</style></div>"
-    `
-    );
+    expect(actualOutput).toMatchSnapshot();
   });
 });
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR fixes an issue reported on Discord where the `<Tailwind>` component was clobbering `<Head>` component contents. This was due to how `rehype` enforces proper HTML structure. Because we were wrapping `<head>` elements with `<div>` to be able to output raw HTML, rehype was wagging its finger because that's not valid HTML. This changes the wrapping element to `<head>` and should resolve the issues.