### PR TITLE
fix(jsx-email): move preview app to peerDeps, isolation for preview tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -88,4 +88,4 @@ jobs:
         # We'll need that for the preview tests below
         run: |
           pnpm i
-          moon app-test:playwright
+          moon app-test:playwright.ci

--- a/apps/test/moon.yml
+++ b/apps/test/moon.yml
@@ -13,14 +13,36 @@ tasks:
 
   install:
     command: playwright install --with-deps
-    deps:
-    - ~:install
     options:
       cache: false
 
   playwright:
-    command: playwright test -x
+    command: playwright test -x --config playwright.dev.ts
     deps:
     - ~:install
     options:
       cache: false
+      runDepsInParallel: false
+
+  playwright.ci:
+    command: playwright test -x
+    deps:
+    - ~:install
+    - ~:setup.ci
+    options:
+      cache: false
+      runDepsInParallel: false
+
+  setup.ci:
+    command: ./scripts/ci-preview-setup.sh
+    options:
+      cache: false
+      runFromWorkspaceRoot: true
+    platform: system
+
+  start.ci:
+    command: ./scripts/ci-preview-start.sh
+    options:
+      cache: false
+      runFromWorkspaceRoot: true
+    platform: system

--- a/apps/test/playwright.config.ts
+++ b/apps/test/playwright.config.ts
@@ -1,9 +1,8 @@
 /* eslint-disable import/no-default-export */
 import { defineConfig, devices } from '@playwright/test';
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+// Note: https://playwright.dev/docs/test-configuration.
+
 export default defineConfig({
   forbidOnly: !!process.env.CI,
   fullyParallel: true,
@@ -13,16 +12,6 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] }
     }
-
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] }
-    // },
-
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] }
-    // }
   ],
   reporter: 'list',
   retries: process.env.CI ? 2 : 0,
@@ -34,12 +23,12 @@ export default defineConfig({
     trace: 'on-first-retry'
   },
   webServer: {
-    command: 'moon app-test:dev',
+    command: 'moon app-test:start.ci',
     env: {
       ENV_TEST_VALUE: 'joker'
     },
     reuseExistingServer: !process.env.CI,
     url: 'http://localhost:55420'
   },
-  workers: process.env.CI ? 1 : undefined
+  workers: process.env.CI ? 1 : void 0
 });

--- a/apps/test/playwright.dev.ts
+++ b/apps/test/playwright.dev.ts
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-default-export */
+import config from './playwright.config';
+
+(config.webServer as any).command = 'moon app-test:dev';
+
+export default Object.assign(config, {});

--- a/apps/test/tests/.snapshots/smoke.spec.ts-Local-Assets-chromium.snap
+++ b/apps/test/tests/.snapshots/smoke.spec.ts-Local-Assets-chromium.snap
@@ -8,16 +8,16 @@
     <img
       id="image"
       alt="Cat"
-      src="http://localhost:55420/@fs/<path-removed>/apps/test/fixtures/static/cat.jpeg"
+      src="http://localhost:55420/@fs/<path-removed>/fixtures/static/cat.jpeg"
       width="200"
       height="200"
       style="border:none;display:block;outline:none;text-decoration:none"
     >
     <a
-      href="http://localhost:55420/@fs/<path-removed>/apps/test/fixtures/static/cat.jpeg"
+      href="http://localhost:55420/@fs/<path-removed>/fixtures/static/cat.jpeg"
       style="color:#067df7;text-decoration:none"
     >
-      http://localhost:55420/@fs/<path-removed>/apps/test/fixtures/static/cat.jpeg
+      http://localhost:55420/@fs/<path-removed>/fixtures/static/cat.jpeg
     </a>
   </body>
 </html>

--- a/apps/test/tests/helpers/html.ts
+++ b/apps/test/tests/helpers/html.ts
@@ -11,7 +11,7 @@ const cleanHTML = (html: string) =>
     .replace(/\r?\n/g, EOL)
     // The .replace removes some playwright locator gunk that slips in otherwise
     .replace(/\r?\n^\s*__playwright_target__.+$/m, '')
-    .replace(/@fs\/(.+)\/apps/g, '@fs/<path-removed>/apps');
+    .replace(/@fs\/(.+)\/fixtures/g, '@fs/<path-removed>/fixtures');
 
 interface GetHtmlOptions {
   deep: boolean;

--- a/packages/jsx-email/package.json
+++ b/packages/jsx-email/package.json
@@ -41,11 +41,11 @@
     "email"
   ],
   "peerDependencies": {
+    "@jsx-email/app-preview": "workspace:^",
     "react": "^18.2.0"
   },
   "dependencies": {
     "@dot/log": "^0.1.3",
-    "@jsx-email/app-preview": "workspace:^",
     "@jsx-email/doiuse-email": "^1.0.1",
     "@radix-ui/react-slot": "1.0.2",
     "@unocss/core": "^0.58.3",

--- a/scripts/ci-preview-setup.sh
+++ b/scripts/ci-preview-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script sets up an independent environment for testing the preview app, outside of this monorepo
+# That's important because how pnpm arranges node_modules within the monorepo give false positives
+# when Vite is loading imports and setting up the preview app for a development mode run. Setting this
+# up in a separate directory alleviates those differences and more closesly represents a user's machine
+# which provides a more accurate test environment
+
+rm -rf /tmp/jsx-email-test
+REPO_DIR=$(pwd)
+pnpm exec create-jsx-email jsx-email-test
+mv -f jsx-email-test /tmp
+cd /tmp/jsx-email-test
+pnpm i
+pnpm add "@jsx-email/app-preview@file:$REPO_DIR/apps/preview"
+pnpm add "jsx-email@file:$REPO_DIR/packages/jsx-email"
+rm -rf templates
+cp -r $REPO_DIR/apps/test/fixtures .

--- a/scripts/ci-preview-start.sh
+++ b/scripts/ci-preview-start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script sets up an independent environment for testing the preview app, outside of this monorepo
+# That's important because how pnpm arranges node_modules within the monorepo give false positives
+# when Vite is loading imports and setting up the preview app for a development mode run. Setting this
+# up in a separate directory alleviates those differences and more closesly represents a user's machine
+# which provides a more accurate test environment
+
+cd /tmp/jsx-email-test
+pnpm exec email preview fixtures


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: jsx-email

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR changes the `@jsx-email/app-preview` dependency to a peerDependency to work around https://github.com/pnpm/pnpm/issues/6603, and allow for the preview tests to be run in isolation outside of the monorepo. This is important for a number of reasons; the primary one making sure that when dependencies are added or removed from the preview app, that the app itself doesn't break in dev mode. 