### PR TITLE
feat(jsx-email): add `bgImage` and `bgColor` props to `<Column>`

### DIFF
--- a/docs/components/column.md
+++ b/docs/components/column.md
@@ -29,4 +29,25 @@ const Email = () => {
 
 ## Component Props
 
-This component has no custom props, but expresses all of the [Common Component Props](https://react.dev/reference/react-dom/components/common) for `ComponentProps<'td'>`.
+```tsx
+export interface ColumnProps extends BaseProps<'td'> {
+  bgColor?: string;
+  bgImage?: string;
+}
+```
+
+```tsx
+bgColor: string;
+```
+
+To set background color in html email, it wraps the `bgcolor` prop of `<td>` tags
+
+```tsx
+bgImage: string;
+```
+
+To set background images in html email, it wraps the `background` prop of `<td>` tags
+
+:::tip
+This component expresses all of the [Common Component Props](https://react.dev/reference/react-dom/components/common) for `ComponentProps<'td'>`.
+:::

--- a/docs/components/column.md
+++ b/docs/components/column.md
@@ -40,13 +40,13 @@ export interface ColumnProps extends BaseProps<'td'> {
 bgColor: string;
 ```
 
-To set background color in html email, it wraps the `bgcolor` prop of `<td>` tags
+Used to set the background color in HTML email by wrapping the `bgcolor` property of `<td>` elements
 
 ```tsx
 bgImage: string;
 ```
 
-To set background images in html email, it wraps the `background` prop of `<td>` tags
+Used to set background images in HTML email by wrapping the `background` property of `<td>` elements
 
 :::tip
 This component expresses all of the [Common Component Props](https://react.dev/reference/react-dom/components/common) for `ComponentProps<'td'>`.

--- a/packages/jsx-email/src/components/column.tsx
+++ b/packages/jsx-email/src/components/column.tsx
@@ -1,12 +1,28 @@
 import { debug } from '../debug';
 import type { BaseProps, JsxEmailComponent } from '../types';
 
-export interface ColumnProps extends BaseProps<'td'> {}
+export interface ColumnProps extends BaseProps<'td'> {
+  bgColor?: string;
+  bgImage?: string;
+}
 
 const debugProps = debug.elements.enabled ? { dataType: 'jsx-email/column' } : {};
 
-export const Column: JsxEmailComponent<ColumnProps> = ({ children, style, ...props }) => (
-  <td {...props} {...debugProps} style={style}>
+export const Column: JsxEmailComponent<ColumnProps> = ({
+  children,
+  bgColor,
+  bgImage,
+  style,
+  ...props
+}) => (
+  <td
+    // @ts-expect-error: `background` and `bgcolor` not documented
+    background={bgImage}
+    bgcolor={bgColor}
+    {...props}
+    {...debugProps}
+    style={style}
+  >
     {children}
   </td>
 );

--- a/packages/jsx-email/test/.snapshots/column.test.tsx.snap
+++ b/packages/jsx-email/test/.snapshots/column.test.tsx.snap
@@ -5,3 +5,7 @@ exports[`<Column> component > passes style and other props correctly 1`] = `"<td
 exports[`<Column> component > renders children correctly 1`] = `"<td>Test message</td>"`;
 
 exports[`<Column> component > renders correctly 1`] = `"<td>Lorem ipsum</td>"`;
+
+exports[`<Column> component > renders correctly with background color 1`] = `"<td bgcolor=\\"#000000\\">Lorem ipsum</td>"`;
+
+exports[`<Column> component > renders correctly with background image 1`] = `"<td background=\\"link-to-image\\">Lorem ipsum</td>"`;

--- a/packages/jsx-email/test/column.test.tsx
+++ b/packages/jsx-email/test/column.test.tsx
@@ -30,4 +30,14 @@ describe('<Column> component', () => {
     const actualOutput = await jsxToString(<Column>Lorem ipsum</Column>);
     expect(actualOutput).toMatchSnapshot();
   });
+
+  it('renders correctly with background color', async () => {
+    const actualOutput = await jsxToString(<Column bgColor="#000000">Lorem ipsum</Column>);
+    expect(actualOutput).toMatchSnapshot();
+  });
+
+  it('renders correctly with background image', async () => {
+    const actualOutput = await jsxToString(<Column bgImage="link-to-image">Lorem ipsum</Column>);
+    expect(actualOutput).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:
`Column`

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
For maximum client compatibility, it is advised to add the background image and color to the `<td>` tag

in HTML email, `bgcolor` is used to set the background color and `background` is used to set background images on the `td` tag.

Read more [here](https://faculty.etsu.edu/tarnoff/ntes1710/tables/tables.htm#:~:text=To%20add%20a%20tiled%20background%20image%20to%20a%20single%20cell%2C%20use%20the%20attribute%20background%3D%22URL%22%20inside%20the%20%3Ctd%3E%20tag)

The `bgColor` and `bgImage` props are just wrappers around `bgcolor` and `background` respectively and it shifts the error handling within the library rather than to the end users (`@ts-expect-error`)
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
