### PR TITLE
fix(jsx-email): linux bin execution bug

### DIFF
--- a/packages/jsx-email/bin/email
+++ b/packages/jsx-email/bin/email
@@ -1,0 +1,2 @@
+#!/usr/bin/env -S node --enable-source-maps --no-warnings=ExperimentalWarning
+import './../dist/esm/cli/main.mjs';

--- a/packages/jsx-email/package.json
+++ b/packages/jsx-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-email",
-  "version": "2.0.6-gildas.2",
+  "version": "2.0.6",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jsx-email/package.json
+++ b/packages/jsx-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-email",
-  "version": "2.0.6",
+  "version": "2.0.6-gildas.2",
   "publishConfig": {
     "access": "public"
   },
@@ -15,7 +15,7 @@
   "homepage": "https://jsx.email/",
   "main": "./dist/commonjs/index.js",
   "bin": {
-    "email": "./dist/esm/cli/index.mjs"
+    "email": "./bin/email"
   },
   "type": "module",
   "exports": {
@@ -45,6 +45,7 @@
     "node": ">=18.0.0"
   },
   "files": [
+    "bin/**",
     "dist/**"
   ],
   "keywords": [

--- a/packages/jsx-email/src/cli/index.mts
+++ b/packages/jsx-email/src/cli/index.mts
@@ -1,3 +1,0 @@
-#!/usr/bin/env node --enable-source-maps --no-warnings=ExperimentalWarning
-
-import './main.mjs';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

User `Gildas` reported on Discord that on his Linux machine, the jsx-email bin file wasn't executable. https://discord.com/channels/1156307748552716398/1156766131462361211/1292472966642274397

Turns out that on Linux, an additional leading `-S` flag is needed to instruct the interpreter to consider and parse everything that follows as a single command. 