### PR TITLE
fix(jsx-email): change how package.json is read so it doesn't break with recent node versions

### DIFF
--- a/packages/jsx-email/src/cli/commands/help.mts
+++ b/packages/jsx-email/src/cli/commands/help.mts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 
-// @ts-ignore
-import pkg from '../../../package.json' assert { type: 'json' };
+import { name, version } from '../../package-info.cjs';
 
 import type { CommandFn } from './types.mjs';
 import { help as build } from './build.mjs';
@@ -12,7 +11,7 @@ import { help as preview } from './preview.mjs';
 const { log } = console;
 
 export const helpMessage = chalk`
-{blue ${pkg.name}} v${pkg.version}
+{blue ${name}} v${version}
 
 The jsx-email CLI. Build, Check, Create and View email templates
 

--- a/packages/jsx-email/src/cli/main.mts
+++ b/packages/jsx-email/src/cli/main.mts
@@ -1,7 +1,7 @@
 import sourceMapSupport from 'source-map-support';
 import yargs from 'yargs-parser';
 
-import pkg from '../../package.json' assert { type: 'json' };
+import { name, version } from '../package-info.cjs';
 
 import { debug } from '../debug.js';
 
@@ -29,7 +29,7 @@ const run = async () => {
   debug.cli(`Command Name: \`${commandName}\``);
 
   if (flags.version) {
-    log(`${pkg.name} v${pkg.version}\n`);
+    log(`${name} v${version}\n`);
     return;
   }
 

--- a/packages/jsx-email/src/package-info.cts
+++ b/packages/jsx-email/src/package-info.cts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line
+const pkg = require('../package.json') as { name: string; version: string };
+
+export const { name, version } = pkg;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: `jsx-email`

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Node v22 deprecated the use of the `assert { type: 'json' }` syntax when importing modules in favour of the `with { type: 'json' }` syntax (they are used when reading JSON). The `assert` syntax was used up until v22, and the `with` syntax _started_ being supported in node v18.20. `jsx-email` supports version 18.19+ meaning using the `with` syntax would be a breaking change. 

The reading of JSON was happening when the cli tool was reading from the `package.json`. This PR introduces the change that instead of reading the `package.json` as a module, we read it inside a `.cts` file which does not use the same `assert`/`with` syntax. 

This PR is a little tricky to test (and why there are no test cases added), but it looks to work on node versions: `18.19.0`, `18.20.0`, and `22.6.0`. I don't believe any issues should occur because the `"esModuleInterop"` option in the `tsconfig.json` is set to `true`, but some extra care wouldn't hurt.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
