### PR TITLE
fix(jsx-email): modify core plugin imports for bundler resolution

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -1,0 +1,69 @@
+name: CLI Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - synchronize
+  push:
+    branches:
+      - '*'
+      - '!main'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    name: CLI Tests
+
+    steps:
+      - name: Checkout Commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+
+      # Needed for https://github.com/moonrepo/moon/issues/1060
+      - name: Force Update Main
+        run: |
+          git fetch origin
+          git branch -f main origin/main
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        id: pnpm-setup
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+          pnpm config set script-shell "/usr/bin/bash"
+
+      - name: Setup Moon
+        uses: moonrepo/setup-toolchain@v0
+
+      - name: Sanity Check
+        run: |
+          echo git `git version`;
+          echo branch `git branch --show-current`;
+          echo node `node -v`;
+          echo pnpm `pnpm -v`
+          echo `moon --version`
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Projects
+        run: |
+          moon jsx-email:build
+          moon create-jsx-email:build
+          moon run :build --query "project~plugin-*"
+
+      - name: Run Tests
+        # Note: We're running `pnpm i` again so that pnpm places the `email` bin in root node_modules
+        # We'll need that for the preview tests below
+        run: |
+          pnpm i
+          moon repo:test.cli

--- a/.npmrc
+++ b/.npmrc
@@ -5,6 +5,7 @@ auth-type=legacy
 
 # pnpm options
 always-auth = true
+auto-install-peers = true
 enable-pre-post-scripts = true
 link-workspace-packages = false
 shamefully-hoist = true

--- a/moon.yml
+++ b/moon.yml
@@ -85,7 +85,10 @@ tasks:
   test.cli:
     command: vitest --config ./shared/vitest.config.ts test/cli --no-threads
     deps:
-      - ~:build.all
+      - jsx-email:build
+      - plugin-inline:build
+      - plugin-minify:build
+      - plugin-pretty:build
     inputs:
       - test/cli
     options:

--- a/packages/jsx-email/src/cli/commands/build.mts
+++ b/packages/jsx-email/src/cli/commands/build.mts
@@ -146,8 +146,6 @@ export const build = async (options: BuildOptions): Promise<BuildResult> => {
 const compile = async (options: CompileOptions) => {
   const config = await loadConfig();
 
-  console.log({ config });
-
   const { files, outDir, writeMeta } = options;
   const { metafile } = await esbuild.build({
     bundle: true,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: jsx-email

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers: resolves #226

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This changes up the way that the config code loads core plugins (inline, minify, pretty) and uses explicit imports, rather than using variables for the import names. That removes the burden of specifying additional modules for webpack etc to inlcude, from users who are bundling jsx-email. Bundlers should automatically pick up those plugins with these changes.

(Validated the fix using webpack)