### PR TITLE
fix(jsx-email,create-jsx-email): dangling width on button in generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .moon/cache
 .eslintcache
 .rendered
+.test
 node_modules
 dist
 .DS_Store

--- a/assets/templates/email.mustache
+++ b/assets/templates/email.mustache
@@ -68,7 +68,6 @@ export const Template = ({ email, name }{{ propsType }}) => (
           <Button
             style={button}
             href="https://example.com"
-            width={'100%'}
             align={'center'}
             backgroundColor={'#777'}
             borderRadius={5}

--- a/packages/create-jsx-email/package.json
+++ b/packages/create-jsx-email/package.json
@@ -43,5 +43,6 @@
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/shellscape"
-  }
+  },
+  "generatorsBump": "0"
 }

--- a/packages/jsx-email/package.json
+++ b/packages/jsx-email/package.json
@@ -123,6 +123,7 @@
     "type": "github",
     "url": "https://github.com/sponsors/shellscape"
   },
+  "generatorsBump": "0",
   "sideEffects": false,
   "tshy": {
     "exports": {

--- a/test/cli/.snapshots/create.test.ts.snap
+++ b/test/cli/.snapshots/create.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`cli > esbuild plugins 1`] = `Promise {}`;

--- a/test/cli/create.test.ts
+++ b/test/cli/create.test.ts
@@ -1,0 +1,28 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { execa } from 'execa';
+import { describe, expect, test } from 'vitest';
+import strip from 'strip-ansi';
+
+process.chdir(__dirname);
+
+describe('cli', async () => {
+  test('esbuild plugins', async () => {
+    const { stdout } = await execa({
+      cwd: __dirname,
+      shell: true
+      // Note: For some reason `pnpm exec` is fucking with our CWD, and resets it to
+      // packages/jsx-email, which causes the config not to be found. so we use npx instead
+    })`email create BatmanEmail --out ./.test/emails `;
+    const plain = strip(stdout);
+
+    console.log(plain);
+
+    expect(plain).toContain('Creating a new template at ');
+    expect(plain).toContain('Template BatmanEmail.tsx created');
+
+    const contents = readFile(join(__dirname, '.test/emails/BatmanEmail.tsx'), 'utf8');
+    expect(contents).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Fixes an issue with the email generator reported in Discord: https://discord.com/channels/1156307748552716398/1300824699739181076