### PR TITLE
fix(jsx-email): dont declare exports for cjs build. fixes #235

### DIFF
--- a/packages/jsx-email/src/config.ts
+++ b/packages/jsx-email/src/config.ts
@@ -239,8 +239,9 @@ export const loadConfig = async (startDir?: string): Promise<JsxEmailConfig> => 
 
   log.debug('loadConfig →', { cwd: process.cwd(), searchResult, startDir });
 
-  const exports: ConfigExports = searchResult?.config ?? {};
-  const intermediate = exports.config instanceof Promise ? await exports.config : exports.config;
+  const configExports: ConfigExports = searchResult?.config ?? {};
+  const intermediate =
+    configExports.config instanceof Promise ? await configExports.config : configExports.config;
   const config = intermediate ?? { ...defaults };
 
   if ((config as any).symbol === configSymbol) {

--- a/test/cli/.snapshots/create-jsx-email.test.ts.snap
+++ b/test/cli/.snapshots/create-jsx-email.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`create-jsx-email > command 1`] = `
 "
-create-jsx-email v2.0.3
+create-jsx-email v2.0.4
 
 The fastest way to get started with JSX Email
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no - We need a separate smoke test for CJS builds because Vitest won't load CJS

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers: Fixes #235

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Prevents a `const exports` declaration which for some reason results in a TSC compilation error beyond our control. 