### PR TITLE
feat(jsx-email,app-preview): --base-path flag, deploy preview to sub path

### DIFF
--- a/apps/preview/app/src/routes.tsx
+++ b/apps/preview/app/src/routes.tsx
@@ -48,7 +48,7 @@ export const getRouter = (templates: Record<string, TemplateData>) => {
         </Layout>
       ),
       errorElement: <Error />,
-      path: '/'
+      path: import.meta.env.VITE_JSXEMAIL_BASE_PATH || '/'
     },
     ...routes
   ]);

--- a/packages/jsx-email/src/cli/commands/types.mts
+++ b/packages/jsx-email/src/cli/commands/types.mts
@@ -1,11 +1,12 @@
 import type React from 'react';
 import { boolean, number, object, optional, string, union, type Output as Infer } from 'valibot';
 
-export type CommandFn = (flags: Flags, inputs: string[]) => Promise<boolean>;
-
 export type Flags = Record<string, string | boolean | undefined>;
 
+export type CommandFn = (flags: Flags, inputs: string[]) => Promise<boolean>;
+
 export const PreviewCommandOptionsStruct = object({
+  basePath: optional(string()),
   buildPath: optional(string()),
   exclude: optional(string()),
   host: optional(boolean()),


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: jsx-email, app-preview

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

resolves #245

### Description

Adds a new `--base-path` flag to the `email preview` command which allows deploying the app to a server sub-path instead of the server root. 