### PR TITLE
fix(jsx-email): export compile method in separate path

### DIFF
--- a/docs/core/compile.md
+++ b/docs/core/compile.md
@@ -16,7 +16,7 @@ type: package
 import { readFile } from 'node:fs/promises;';
 import { resolve } from 'node:path';
 
-import { compile } from 'jsx-email';
+import { compile } from 'jsx-email/compile';
 
 const templatePath = resolve(__dirname, './emails/Batman');
 const outputDir = resolve(__dirname, '.compiled');

--- a/packages/jsx-email/src/index.ts
+++ b/packages/jsx-email/src/index.ts
@@ -28,7 +28,6 @@ export * from './components/text.js';
 // renderer
 export * from './renderer/compat/context.js';
 export * from './renderer/compat/hooks.js';
-export * from './renderer/compile.js';
 export * from './renderer/jsx-to-string.js';
 export * from './renderer/render.js';
 export { useData } from './renderer/suspense.js';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

Related to #248. 

### Description

This really isn't a problem with jsx-email, but it's causing Nextjs users pain. This is technically a breaking change, but the use of the `compile` export hasn't taken hold yet since it was just released a day or two ago, so we're going to go off-script a bit and do a technically-breaking-change in a patch release. You can yell at me if you'd like, it's OK I can take it. 

Nextjs crappy bundling strikes again. The web is littered with people who have the unfortunate situation of importing a module which happens to import ebuild, and webpack _shockingly he said sarcastically_ doesn't tree shake it out. So users end up with bundling errors after having done seemingly nothing wrong.

I really dislike Nextjs for stuff like this, and the fact that they're still using webpack in 2024 is [mind bottling](https://www.youtube.com/watch?v=rSfebOXSBOE). 