### PR TITLE
fix(preview): fix router when deployed on subpath

### DIFF
--- a/apps/preview/app/src/routes.tsx
+++ b/apps/preview/app/src/routes.tsx
@@ -40,18 +40,23 @@ const getRoutes = (templates: TemplateData[]) => {
 
 export const getRouter = (templates: Record<string, TemplateData>) => {
   const { routes, templateParts } = getRoutes(Object.values(templates));
-  const router = createBrowserRouter([
+  const router = createBrowserRouter(
+    [
+      {
+        element: (
+          <Layout>
+            <Home templateParts={templateParts} />
+          </Layout>
+        ),
+        errorElement: <Error />,
+        path: '/'
+      },
+      ...routes
+    ],
     {
-      element: (
-        <Layout>
-          <Home templateParts={templateParts} />
-        </Layout>
-      ),
-      errorElement: <Error />,
-      path: import.meta.env.VITE_JSXEMAIL_BASE_PATH || '/'
-    },
-    ...routes
-  ]);
+      basename: import.meta.env.VITE_JSXEMAIL_BASE_PATH
+    }
+  );
 
   return router;
 };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers: https://github.com/shellscape/jsx-email/issues/245

This PR fixes an incorrect setting introduced here https://github.com/shellscape/jsx-email/pull/247



<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

The preview still doesn't work when deployed on the subpath.  Assets are loaded but router configured incorrectly and returns Route not Found error

I'm filling a bit guilty, because I proposed this solution, but actually i didn't test it and speculated only looking to the code on the github. It turned out that the basepath should go into the `basename` router parameter. 

