### PR TITLE
fix(jsx-email): deprecate the `base-path` flag

### DIFF
--- a/packages/jsx-email/src/cli/commands/preview.mts
+++ b/packages/jsx-email/src/cli/commands/preview.mts
@@ -37,7 +37,6 @@ Starts the preview server for a directory of email templates
   $ email preview <template dir path> [...options]
 
 {underline Options}
-  --base-path   Default: /. Defines the path on a server that the preview app will be deployed to or available at
   --build-path  An absolute path. When set, builds the preview as a deployable app and saves to disk
   --exclude     A micromatch glob pattern that specifies files to exclude from the preview
   --host        Allow thew preview server to listen on all addresses (0.0.0.0)
@@ -50,6 +49,12 @@ Starts the preview server for a directory of email templates
 `;
 
 const buildDeployable = async ({ argv, targetPath }: PreviewCommonParams) => {
+  if (argv.basePath) {
+    log.warn(
+      chalk`The {yellow basePath} flag is depcrecated. The preview now deploys to a relative root by default. This flag is no longer needed`
+    );
+  }
+
   const { basePath = './', buildPath } = argv;
   const common = { argv, targetPath };
   await prepareBuild(common);


### PR DESCRIPTION
The preview deployed on a subpath after changing to the `createHashRouter` is not working. It's because 

```js
path: import.meta.env.VITE_JSXEMAIL_BASE_PATH || '/'
```

Saying that the root component of the router tree should have this path, with a combination of hash router this leads to 


```bash
email preview ./emails/templates --build-path /tmp/email-preview --base-path pr-223/emails
```

Correct root URL would be: 

```
/pr-223/emails#/pr-223/emails
```

The `path` part is needed for proper asset serving as defined in Vite, the `hash` part is needed for router, as stated for root route. 

Where expected URL is

```
/pr-223/emails#/
```

I also removed a base-path property from the cli, since it's not needed and only lead to broken build. With a `./` base path Vite should generate a portable artifact already. 

This is basically a breaking change, because I deleted a flag, but because this never worked as expected I left it up to you. 

## How i tested it

```bash
moon repo:build.all
email preview ./apps/demo/emails --build-path /tmp/email-preview/subpath
npx http-server /tmp/email-preview
```

Then opened 

http://127.0.0.1:8080/subpath and tested that navigation works as expected

Also tested without subpath - it also works, no issue. 

## Component / Package Name:
`jsx-email`, `@jsx-email/preview`

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
