### PR TITLE
chore(repo): add JSX_DEV_LOCAL for local preview dev

### DIFF
--- a/packages/jsx-email/src/cli/commands/preview.mts
+++ b/packages/jsx-email/src/cli/commands/preview.mts
@@ -27,6 +27,7 @@ import {
 
 // eslint-disable-next-line no-console
 const newline = () => console.log('');
+const { JSX_DEV_LOCAL = false } = process.env;
 
 export const help = chalk`
 {blue email preview}
@@ -83,9 +84,13 @@ const buildDeployable = async ({ argv, targetPath }: PreviewCommonParams) => {
 
 const getConfig = async ({ argv, targetPath }: PreviewCommonParams) => {
   const buildPath = await getTempPath('preview');
-  // @ts-ignore
-  const root = fileURLToPath(import.meta.resolve('../../../preview'));
+  const root = JSX_DEV_LOCAL
+    ? fileURLToPath(import.meta.resolve('../../../../../../apps/preview/app'))
+    : fileURLToPath(import.meta.resolve('../../../preview'));
   const { basePath = '/', host = false, port = 55420 } = argv;
+
+  if (JSX_DEV_LOCAL)
+    log.warn(chalk`{yellow JSX_DEV_LOCAL is set}. using preview source from ${root}`);
 
   log.debug(`Vite Root: ${root}`);
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: jsx-email

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Introduces support for `JSX_DEV_LOCAL` which instructs the preview to point vite at `apps/preview` instead of the local preview app source in `packages/jsx-email/dist`. Used for local development of the preview app within the repo only.

Example usage: `JSX_DEV_LOCAL=true moon demo:dev`