### PR TITLE
ci: run tests on windows

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -14,7 +14,10 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     name: CLI Tests
 
     steps:

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -14,7 +14,10 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     name: Smoke Tests
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,10 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     name: Run Tests
 
     steps:


### PR DESCRIPTION
I have users [reporting issues](https://github.com/timofei-iatsenko/keycloakify-emails/issues/5) on windows. I configured smoke tests for the application on windows and indeed it's failing.

I searched through issues and there were a bunch of windows issues previously fixed, but tests in the CI were not added. That's why I'm adding them to showcase the problems on windows.

Regarding current issue, example of failing WF is here 

https://github.com/timofei-iatsenko/keycloakify-emails/actions/runs/12416203815/job/34664284560

It's failing with: 

```
ReferenceError: require is not defined
    at moduleImport (file:///D:/a/keycloakify-emails/keycloakify-emails/node_modules/.pnpm/jsx-email@2.5.3_patch_hash=lw572etmmjvpxarowkqqptjobm_@jsx-email+plugin-inline@1.0.1_@jsx-ema_3cnz4xvaxhfemvgnnu2s7rzzne/node_modules/jsx-email/src/config.ts:201:6)
    at Object.search (D:\a\keycloakify-emails\keycloakify-emails\node_modules\.pnpm\lilconfig@3.1.2\node_modules\lilconfig\src\index.js:222:23)
    at loadConfig (file:///D:/a/keycloakify-emails/keycloakify-emails/node_modules/.pnpm/jsx-email@2.5.3_patch_hash=lw572etmmjvpxarowkqqptjobm_@jsx-email+plugin-inline@1.0.1_@jsx-ema_3cnz4xvaxhfemvgnnu2s7rzzne/node_modules/jsx-email/src/config.ts:219:14)
    at render (file:///D:/a/keycloakify-emails/keycloakify-emails/node_modules/.pnpm/jsx-email@2.5.3_patch_hash=lw572etmmjvpxarowkqqptjobm_@jsx-email+plugin-inline@1.0.1_@jsx-ema_3cnz4xvaxhfemvgnnu2s7rzzne/node_modules/jsx-email/src/renderer/render.ts:46:16)
    at Object.getTemplate (file:///D:/a/keycloakify-emails/keycloakify-emails/example/emails/templates/email-test.tsx:35:10)
    at renderTemplate (file:///D:/a/keycloakify-emails/keycloakify-emails/dist/index.mjs:68:20)
    at renderThemeVariant (file:///D:/a/keycloakify-emails/keycloakify-emails/dist/index.mjs:162:5)
```

I dug into jsx-email sourcecode, it seems problem is here: 

https://github.com/shellscape/jsx-email/blob/29851f2f3dc947b473baf73cf2a5bffa38c58afa/packages/jsx-email/src/config.ts#L194-L210

The first try catch is actually hiding the original issue. I patched the sourcecode and added another `throw` to reveal the original error message and got this one:

> Error: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'

Worth mentioning that similar issue was not reproducible in my test suite in Vite, i suppose it's because vite is doing some pre-processing for files and nodejs receives not original import.

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
