### PR TITLE
chore(repo): quick start typo

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -34,7 +34,7 @@ $ npm create jsx-email
 
 This command will install and execute `create-jsx-email`, create a `email-project` directory, and add a starter template.
 
-While the _Existing Projects_ section below can be safely skipped, the information beneath it is useful and worth giving a read before working with JSX email, as it contains infmroation on the project and template that was just created.
+While the _Existing Projects_ section below can be safely skipped, the information beneath it is useful and worth giving a read before working with JSX email, as it contains information on the project and template that was just created.
 
 ## Existing Projects
 


### PR DESCRIPTION
Correct spelling error in quickstart.

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no


### Description

This PR corrects a single grammatical error in the documentation. Spelling goodly is a delight and makes our work seem more professional, so I figured it couldn't hurt to open the PR.
