### PR TITLE
[Generator] Add react-dom to devDeps

### DIFF
--- a/packages/create-jsx-email/generators/package.json.mustache
+++ b/packages/create-jsx-email/generators/package.json.mustache
@@ -12,6 +12,7 @@
     "jsx-email": "^2.0.0"
   },
   "devDependencies": {
-    "react": "^19.0.0"{{{ typeDep }}}
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"{{{ typeDep }}}
   }
 }


### PR DESCRIPTION
When trying the starter command `pnpm create jsx-email` and selecting `Typescript`, the project fails to run. Adding react-dom fixes this issue

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Current test pass.

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
While running `$ pnpm create jsx-email`, after successful creation of a project and installing packages via `pnpm i` running the project with `pnpm dev` there is an error in the console which prevents the dev env from running. Adding `react-dom` to the package.json fixed this issue. 

```
Uncaught TypeError: can't access property "ReactCurrentDispatcher", ReactSharedInternals is undefined
    React 2
    __require http://localhost:55420/@fs/Users/ryanguarascia/Documents/Personal/Test/test2/node_modules/.pnpm/jsx-email@2.7.2_@jsx-email+plugin-inline@1.0.1_@jsx-email+plugin-minify@1.0.2_@jsx-emai_27eb24c976f8ddef97f9f7afecd9af83/node_modules/jsx-email/dist/node_modules/.vite/deps/chunk-BUSYA2B4.js?v=cc0c0df6:3
    dom React
    __require http://localhost:55420/@fs/Users/ryanguarascia/Documents/Personal/Test/test2/node_modules/.pnpm/jsx-email@2.7.2_@jsx-email+plugin-inline@1.0.1_@jsx-email+plugin-minify@1.0.2_@jsx-emai_27eb24c976f8ddef97f9f7afecd9af83/node_modules/jsx-email/dist/node_modules/.vite/deps/chunk-BUSYA2B4.js?v=cc0c0df6:3
    dom React
    __require http://localhost:55420/@fs/Users/ryanguarascia/Documents/Personal/Test/test2/node_modules/.pnpm/jsx-email@2.7.2_@jsx-email+plugin-inline@1.0.1_@jsx-email+plugin-minify@1.0.2_@jsx-emai_27eb24c976f8ddef97f9f7afecd9af83/node_modules/jsx-email/dist/node_modules/.vite/deps/chunk-BUSYA2B4.js?v=cc0c0df6:3
    <anonymous> http://localhost:55420/@fs/Users/ryanguarascia/Documents/Personal/Test/test2/node_modules/.pnpm/jsx-email@2.7.2_@jsx-email+plugin-inline@1.0.1_@jsx-email+plugin-minify@1.0.2_@jsx-emai_27eb24c976f8ddef97f9f7afecd9af83/node_modules/jsx-email/dist/node_modules/.vite/deps/react-dom_client.js?v=189c18a4:38
[react-dom.development.js:994:30](http://localhost:55420/@fs/Users/ryanguarascia/Documents/Personal/Test/test2/node_modules/.pnpm/react-dom@18.3.1_react@19.1.0/node_modules/react-dom/cjs/react-dom.development.js)
    React 2
    __require chunk-BUSYA2B4.js:3
    js React
    __require chunk-BUSYA2B4.js:3
    js React
    __require chunk-BUSYA2B4.js:3
    <anonymous> react-dom_client.js:38
```