### PR TITLE
fix: support linebreaks in Raw element

### DIFF
--- a/packages/jsx-email/src/renderer/render.ts
+++ b/packages/jsx-email/src/renderer/render.ts
@@ -95,7 +95,7 @@ const processHtml = async (config: JsxEmailConfig, html: string) => {
   let result = docType + String(doc).replace('<!doctype html>', '').replace('<head></head>', '');
 
   result = result.replace(reJsxTags, '');
-  result = result.replace(/<jsx-email-raw.*?><!--(.*?)--><\/jsx-email-raw>/g, (_, p1) =>
+  result = result.replace(/<jsx-email-raw.*?><!--(.*?)--><\/jsx-email-raw>/gs, (_, p1) =>
     unescapeForRawComponent(p1)
   );
 

--- a/packages/jsx-email/test/.snapshots/raw.test.tsx.snap
+++ b/packages/jsx-email/test/.snapshots/raw.test.tsx.snap
@@ -4,6 +4,12 @@ exports[`<Raw> component > Should preserve content on plainText render 1`] = `"<
 
 exports[`<Raw> component > Should render without escaping 1`] = `"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><html><body><#if firstname & lastname>Ola!</#if></body></html>"`;
 
+exports[`<Raw> component > Should work correctly when it has linebreaks 1`] = `
+"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><html><body>
+            Raw context
+        </body></html>"
+`;
+
 exports[`<Raw> component > Should work correctly with a comment as a content 1`] = `"<!DOCTYPE html PUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><html><body><!--[if !mso]><!-->Ola!<!--<![endif]/--></body></html>"`;
 
 exports[`<Raw> component > disablePlainTextOutput > Should not output to the plain text when enabled 1`] = `"Ola!"`;

--- a/packages/jsx-email/test/raw.test.tsx
+++ b/packages/jsx-email/test/raw.test.tsx
@@ -46,6 +46,19 @@ describe('<Raw> component', async () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('Should work correctly when it has linebreaks', async () => {
+    const actual = await render(
+      <>
+        <Raw
+          content={`
+            Raw context
+        `}
+        />
+      </>
+    );
+    expect(actual).toMatchSnapshot();
+  });
+
   describe('disablePlainTextOutput', () => {
     it('Should not output to the plain text when enabled', async () => {
       const actual = await render(


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: `<Raw />`

Support linebreaks in the `<Raw>` element. I came across this issue trying to implement some more complicated logic for keycloack email templates: 

```jsx
        <Raw
          content={`
    <#assign requiredActionsText>
        <#if requiredActions??>
           <#list requiredActions>
              <#items as reqActionItem>
                 \${msg("requiredAction.\${reqActionItem}")} <#sep>,</#sep>
              </#items>
           </#list>
        </#if>
    </#assign>
    `}
        />
```

And that was rendered with underlying `<jsx-email-raw><!-- ... --></jsx-email-raw>`:

```html
<jsx-email-raw><!--
    <#assign requiredActionsText>
        <#if requiredActions??>
           <#list requiredActions>
              <#items as reqActionItem>
                 ${msg("requiredAction.${reqActionItem}")} <#sep>,</#sep>
              </#items>
           </#list>
        </#if>
    </#assign>
    --></jsx-email-raw>
```


This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
