### PR TITLE
fix(jsx-email): remove external for preview deployment build

### DIFF
--- a/packages/jsx-email/src/cli/commands/preview.mts
+++ b/packages/jsx-email/src/cli/commands/preview.mts
@@ -68,7 +68,6 @@ const buildDeployable = async ({ argv, targetPath }: PreviewCommonParams) => {
       minify: false,
       outDir: buildPath,
       rollupOptions: {
-        external: ['react/jsx-runtime'],
         output: {
           manualChunks: {}
         }


### PR DESCRIPTION
resolves #310
reverts #282 

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

> **I haven't added tests because you don't already have any for previewing (AFAICT) and I can't even begin to think how I would add them from scratch.**

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Externalising `react/jsx-runtime` makes it impossible to serve the built preview app to any browser. It seems #282 did this to fix the preview dev server, but I don't have any issues running the dev server locally after making my change.