### PR TITLE
docs: add Upyo email provider integration example

### DIFF
--- a/docs/email-providers.md
+++ b/docs/email-providers.md
@@ -178,3 +178,34 @@ plunk.emails.send({
   body: html
 });
 ```
+
+## Upyo
+
+```tsx
+import { render } from 'jsx-email';
+import { SmtpTransport } from '@upyo/smtp';
+import { createMessage } from '@upyo/core';
+
+import { Template } from './emails/Batman.tsx';
+
+const transport = new SmtpTransport({
+  host: 'smtp.forwardemail.net',
+  port: 465,
+  secure: true,
+  auth: {
+    user: 'batman',
+    pass: 'j0ker$mells!1'
+  }
+});
+
+const html = await render(<Template firstName="Bruce" lastName="Wayne" />);
+
+const message = createMessage({
+  from: 'penguin@joker.us',
+  to: 'bruce@wayneinc.com',
+  subject: 'Did you get that thing I sent you?',
+  content: { html }
+});
+
+await transport.send(message);
+```

--- a/packages/jsx-email/README.md
+++ b/packages/jsx-email/README.md
@@ -66,7 +66,7 @@ The goals of this project are to provide an improved focus on Developer Experien
 ## Service Integrations
 
 Email built and rendered with JSX email can be used with any email provider that provides an API for sending email as a `String`.
-This includes [AWS SES](https://aws.amazon.com/ses), [Loops](https://loops.so), [Nodemailer](https://nodemailer.com), [Postmark](https://postmarkapp.com),[Resend](https://resend.com), [Plunk](https://www.useplunk.com/), and [SendGrid](https://sendgrid.com). See our documentation on [Email Providers](https://jsx.email/docs/email-providers) for more info and example usage.
+This includes [AWS SES](https://aws.amazon.com/ses), [Loops](https://loops.so), [Nodemailer](https://nodemailer.com), [Postmark](https://postmarkapp.com),[Resend](https://resend.com), [Plunk](https://www.useplunk.com/), [SendGrid](https://sendgrid.com), and [Upyo](https://upyo.org/). See our documentation on [Email Providers](https://jsx.email/docs/email-providers) for more info and example usage.
 
 <!-- FIXME: Write and link to example code for integrations on the docs site -->
 


### PR DESCRIPTION
## Component / Package Name: Documentation

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

N/A

### Description

Adds Upyo integration example to the email providers documentation.

Added Upyo example to `docs/email-providers.md` with SMTP transport configuration and updated `README.md` Service Integrations section to include Upyo.

[Upyo](https://upyo.org/) is a modern email library that provides a universal interface for sending emails across different runtimes. The example follows the same pattern as existing providers and demonstrates how to render jsx-email templates with Upyo's API.
