### PR TITLE
fix: change build command to use relative paths for output directories

### DIFF
--- a/packages/jsx-email/src/cli/commands/build.mts
+++ b/packages/jsx-email/src/cli/commands/build.mts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, realpath, writeFile } from 'node:fs/promises';
 import os from 'node:os';
-import { dirname, basename, extname, join, resolve, win32, posix } from 'path';
+import { dirname, basename, extname, join, resolve, win32, posix, relative } from 'path';
 import { pathToFileURL } from 'url';
 
 import chalk from 'chalk';
@@ -121,8 +121,9 @@ export const build = async (options: BuildOptions): Promise<BuildResult> => {
   const templateName = basename(path, fileExt).replace(/-[^-]{8}$/, '');
   const component = componentExport(renderProps);
   const baseDir = dirname(path);
+  const relativeBaseDir = outputBasePath ? relative(outputBasePath, baseDir) : '';
   const writePath = outputBasePath
-    ? join(out!, baseDir.replace(outputBasePath, ''), templateName)
+    ? join(out!, relativeBaseDir, templateName)
     : join(out!, templateName);
   // const writePath = outputBasePath
   //   ? join(out!, baseDir.replace(outputBasePath, ''), templateName + extension)


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name: jsx-email

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no (see https://github.com/shellscape/jsx-email/issues/307#issuecomment-3276763292)

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:
resolves #307 

### Description

Fixes CLI command usage on Windows

See comment by @shellscape https://github.com/shellscape/jsx-email/issues/307#issuecomment-3276763292
