### PR TITLE
fix(jsx-email): resolve relative build paths on darwin/linux correctly

### DIFF
--- a/.github/workflows/test-v18.yml
+++ b/.github/workflows/test-v18.yml
@@ -50,6 +50,4 @@ jobs:
           moon run :build --query "project~plugin-*"
 
       - name: Package Tests
-        env:
-          FORCE_COLOR: 1
         run: moon run jsx-email:test.ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,4 @@ jobs:
           moon run :build --query "project~plugin-*"
 
       - name: Package Tests
-        env:
-          FORCE_COLOR: 1
         run: moon run jsx-email:test.ci

--- a/packages/jsx-email/moon.yml
+++ b/packages/jsx-email/moon.yml
@@ -63,6 +63,8 @@ tasks:
 
   test.ci:
     command: vitest --config ../../shared/vitest.config.ts
+    env:
+      FORCE_COLOR: '1'
     options:
       outputStyle: 'stream'
 

--- a/packages/jsx-email/src/renderer/compile.ts
+++ b/packages/jsx-email/src/renderer/compile.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from 'node:fs/promises';
-import { dirname, basename, extname, join, resolve } from 'path';
+import { dirname, basename, extname, join, isAbsolute, posix, resolve, win32 } from 'path';
 
 import esbuild from 'esbuild';
 
@@ -87,8 +87,11 @@ export const compile = async (options: CompileOptions): Promise<CompileResult[]>
 
   if (metafile && writeMeta) {
     const ops = Object.entries(outputs).map(async ([path]) => {
-      const fileName = basename(path, extname(path));
-      const metaPath = join(dirname(path), `${fileName}.meta.json`);
+      const outPath = resolveOutputPath(outDir, path);
+      const fileName = basename(outPath, extname(outPath));
+      const metaPath = join(dirname(outPath), `${fileName}.meta.json`);
+      // const fileName = basename(path, extname(path));
+      // const metaPath = join(dirname(path), `${fileName}.meta.json`);
       const writePath = resolve(originalCwd, metaPath);
       const json = JSON.stringify(metafile);
 
@@ -99,4 +102,27 @@ export const compile = async (options: CompileOptions): Promise<CompileResult[]>
   }
 
   return affectedFiles;
+};
+
+export const resolveOutputPath = (
+  outDir: string,
+  outKey: string,
+  cwd: string = originalCwd
+): string => {
+  // Absolute (platform current) or Windows-style absolute
+  // Do not normalize separators; return exactly as provided
+  if (isAbsolute(outKey) || win32.isAbsolute(outKey)) {
+    return outKey;
+  }
+
+  // macOS: keys may omit the leading '/'
+  // e.g., outDir: '/private/var/.../build' and key: 'private/var/.../build/file.js'
+  if (posix.isAbsolute(outDir)) {
+    const outNoLead = outDir.slice(1);
+    if (outKey.startsWith(outNoLead + posix.sep)) {
+      return posix.join(posix.sep, outKey);
+    }
+  }
+
+  return resolve(cwd, outKey);
 };

--- a/packages/jsx-email/test/render/compile-path.test.ts
+++ b/packages/jsx-email/test/render/compile-path.test.ts
@@ -1,0 +1,45 @@
+import { resolve } from 'node:path';
+
+import { resolveOutputPath } from '../../src/renderer/compile.js';
+
+describe('resolveOutputPath', () => {
+  it('returns absolute testPath as-is', () => {
+    const outDir = '/tmp/jsx-email/build';
+    const testPath = '/tmp/jsx-email/build/email-123.js';
+    const expected = resolveOutputPath(outDir, testPath);
+    const actual = testPath;
+    expect(expected).toEqual(actual);
+  });
+
+  it('handles macOS testPaths without leading slash', () => {
+    const outDir = '/private/var/folders/07/abc/T/jsx-email/build';
+    const testPath = 'private/var/folders/07/abc/T/jsx-email/build/email-XYZ.js';
+    const expected = resolveOutputPath(outDir, testPath);
+    const actual = `/${testPath}`;
+    expect(expected).toEqual(actual);
+  });
+
+  it('resolves relative testPaths against CWD (esbuild behavior)', () => {
+    const outDir = resolve(__dirname, '.compiled');
+    const testPath = 'nested/email.js';
+    const expected = resolveOutputPath(outDir, testPath, process.cwd());
+    const actual = resolve(process.cwd(), testPath);
+    expect(expected).toEqual(actual);
+  });
+
+  it('does not duplicate outDir when testPath already includes it and outDir is relative', () => {
+    const outDir = 'dist';
+    const testPath = 'dist/email.js';
+    const expected = resolveOutputPath(outDir, testPath, process.cwd());
+    const actual = resolve(process.cwd(), testPath);
+    expect(expected).toEqual(actual);
+  });
+
+  it('treats Windows drive-letter testPaths as absolute', () => {
+    const outDir = 'dist';
+    const testPath = 'C:/tmp/jsx-email/build/email.js';
+    const expected = resolveOutputPath(outDir, testPath, process.cwd());
+    const actual = testPath;
+    expect(expected).toEqual(actual);
+  });
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Resolves a situation in which a relative path from esbuild during the build/compile/render pipeline ends up with a bad temp path join. 