### PR TITLE
chore(repo): adjust website bg image opacity to improve mobile contrast and readability

### DIFF
--- a/apps/web/.vitepress/theme/custom.css
+++ b/apps/web/.vitepress/theme/custom.css
@@ -220,6 +220,10 @@ img.clients {
   .VPHomeHero .text {
     height: auto;
   }
+  .VPContent {
+    /* Less visible to not obscure overlapping content */
+    background-image: url(/landing-bg-muted.svg);
+  }
 }
 
 table.recipes {

--- a/apps/web/src/public/landing-bg-muted.svg
+++ b/apps/web/src/public/landing-bg-muted.svg
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="1200px"
+   height="669px"
+   viewBox="0 0 1200 669"
+   version="1.1"
+   id="svg22"
+   sodipodi:docname="landing-bg-muted.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs22" />
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.60313901"
+     inkscape:cx="585.27138"
+     inkscape:cy="302.58364"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1072"
+     inkscape:window-y="358"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g21" />
+  <g
+     stroke="none"
+     stroke-width="1"
+     fill="none"
+     fill-rule="evenodd"
+     id="g22">
+    <g
+       id="Real-Time"
+       transform="translate(0.000000, -564.000000)">
+      <g
+         id="index-teletype-graphic"
+         transform="translate(0.000000, 564.000000)">
+        <g
+           id="Right">
+          <g
+             id="Split-Lines"
+             opacity="0.244735054"
+             transform="translate(0.000000, 589.000000)">
+            <path
+               d="M475,64 L499,64 L499,80 L475,80 L475,64 Z M323,64 L443,64 L443,80 L323,80 L323,64 Z M259,64 L291,64 L291,80 L259,80 L259,64 Z M163,64 L227,64 L227,80 L163,80 L163,64 Z M115,64 L131,64 L131,80 L115,80 L115,64 Z"
+               fill="#659CC8"
+               id="path1" />
+            <path
+               d="M320,0 L368,0 L368,32 L320,32 L320,0 Z M240,0 L288,0 L288,32 L240,32 L240,0 Z M128,0 L208,0 L208,32 L128,32 L128,0 Z M80,0 L96,0 L96,32 L80,32 L80,0 Z M0,0 L48,0 L48,32 L0,32 L0,0 Z"
+               fill="#78AF9F"
+               id="path2" />
+          </g>
+          <g
+             id="g5"
+             opacity="0.0674818841"
+             transform="translate(51.000000, 0.000000)">
+            <path
+               d="M474,112 L498,112 L498,160 L474,160 L474,112 Z M266,112 L442,112 L442,160 L266,160 L266,112 Z M138,112 L234,112 L234,160 L138,160 L138,112 Z M82,112 L106,112 L106,160 L82,160 L82,112 Z"
+               fill="#DDA032"
+               id="path3" />
+            <path
+               d="M288,48 L312,48 L312,80 L288,80 L288,48 Z M160,48 L256,48 L256,80 L160,80 L160,48 Z M64,48 L128,48 L128,80 L64,80 L64,48 Z M0,48 L32,48 L32,80 L0,80 L0,48 Z"
+               fill="#D36E2D"
+               id="path4" />
+            <path
+               d="M416,1.0658141e-14 L448,1.0658141e-14 L448,16 L416,16 L416,1.0658141e-14 Z M224,1.0658141e-14 L384,1.0658141e-14 L384,16 L224,16 L224,1.0658141e-14 Z M176,1.0658141e-14 L192,1.0658141e-14 L192,16 L176,16 L176,1.0658141e-14 Z M80,1.0658141e-14 L144,1.0658141e-14 L144,16 L80,16 L80,1.0658141e-14 Z"
+               fill="#C13F21"
+               id="path5" />
+          </g>
+          <g
+             transform="translate(184.000000, 252.000000)"
+             id="g10">
+            <path
+               d="m 312,128 h 166.06219 l -0.0733,8 H 312 Z m -76,0 h 60 v 8 h -60 z m -32,0 h 16 v 8 h -16 z m -48,0 h 32 v 8 h -32 z m -24,0 h 8 v 8 h -8 z"
+               fill="#659cc8"
+               id="path6"
+               style="opacity:0.248"
+               sodipodi:nodetypes="ccccccccccccccccccccccccc" />
+            <path
+               d="m 224,96 h 253.98891 l 0.14652,16 H 224 Z m -40,0 h 24 v 16 h -24 z m -56,0 h 40 v 16 h -40 z m -24,0 h 8 v 16 h -8 z m -40,0 h 24 v 16 H 64 Z"
+               fill="#78af9f"
+               id="path7"
+               style="opacity:0.242"
+               sodipodi:nodetypes="ccccccccccccccccccccccccc" />
+            <path
+               d="m 196,56 h 281.98891 l -0.0733,24 H 196 Z M 92,56 h 88 V 80 H 92 Z M 28,56 H 76 V 80 H 28 Z M 0,56 H 12 V 80 H 0 Z"
+               fill="#dda032"
+               id="path8"
+               style="opacity:0.067"
+               sodipodi:nodetypes="cccccccccccccccccccc" />
+            <path
+               d="m 228,24 h 250.06219 l 0.0733,16 H 228 Z m -64,0 h 48 v 16 h -48 z m -48,0 h 32 v 16 h -32 z m -32,0 h 16 V 40 H 84 Z"
+               fill="#d36e2d"
+               id="path9"
+               style="opacity:0.067"
+               sodipodi:nodetypes="cccccccccccccccccccc" />
+            <path
+               d="m 218,0 h 259.99986 l 0.0259,8 H 218 Z m -96,0 h 80 V 8 H 122 Z M 98,0 h 8 V 8 H 98 Z M 50,0 H 82 V 8 H 50 Z"
+               fill="#c13f21"
+               id="path10"
+               style="opacity:0.067"
+               sodipodi:nodetypes="cccccccccccccccccccc" />
+          </g>
+        </g>
+        <g
+           transform="translate(925.500000, 334.500000) scale(-1, 1) translate(-925.500000, -334.500000) translate(651.000000, 0.000000)"
+           id="g21">
+          <g
+             id="g12"
+             opacity="0.244735054"
+             transform="translate(166.000000, 589.000000)">
+            <path
+               d="M323,64 L383,64 L383,80 L323,80 L323,64 Z M259,64 L291,64 L291,80 L259,80 L259,64 Z M163,64 L227,64 L227,80 L163,80 L163,64 Z M115,64 L131,64 L131,80 L115,80 L115,64 Z"
+               fill="#659CC8"
+               id="path11" />
+            <path
+               d="M320,0 L368,0 L368,32 L320,32 L320,0 Z M240,0 L288,0 L288,32 L240,32 L240,0 Z M128,0 L208,0 L208,32 L128,32 L128,0 Z M80,0 L96,0 L96,32 L80,32 L80,0 Z M0,0 L48,0 L48,32 L0,32 L0,0 Z"
+               fill="#78AF9F"
+               id="path12" />
+          </g>
+          <g
+             id="g15"
+             opacity="0.0674818841"
+             transform="translate(151.000000, 0.000000)">
+            <path
+               d="M266,112 L336,112 L336,160 L266,160 L266,112 Z M138,112 L234,112 L234,160 L138,160 L138,112 Z M82,112 L106,112 L106,160 L82,160 L82,112 Z"
+               fill="#DDA032"
+               id="path13" />
+            <path
+               d="M288,48 L312,48 L312,80 L288,80 L288,48 Z M160,48 L256,48 L256,80 L160,80 L160,48 Z M64,48 L128,48 L128,80 L64,80 L64,48 Z M0,48 L32,48 L32,80 L0,80 L0,48 Z"
+               fill="#D36E2D"
+               id="path14" />
+            <path
+               d="M224,1.0658141e-14 L384,1.0658141e-14 L384,16 L224,16 L224,1.0658141e-14 Z M176,1.0658141e-14 L192,1.0658141e-14 L192,16 L176,16 L176,1.0658141e-14 Z M80,1.0658141e-14 L144,1.0658141e-14 L144,16 L80,16 L80,1.0658141e-14 Z"
+               fill="#C13F21"
+               id="path15" />
+          </g>
+          <g
+             transform="translate(0.000000, 252.000000)"
+             id="g20">
+            <path
+               d="M312,128 L538,128 L538,136 L312,136 L312,128 Z M236,128 L296,128 L296,136 L236,136 L236,128 Z M204,128 L220,128 L220,136 L204,136 L204,128 Z M156,128 L188,128 L188,136 L156,136 L156,128 Z M132,128 L140,128 L140,136 L132,136 L132,128 Z"
+               fill="#659CC8"
+               id="path16"
+               style="opacity:0.248" />
+            <path
+               d="M224,96 L538,96 L538,112 L224,112 L224,96 Z M184,96 L208,96 L208,112 L184,112 L184,96 Z M128,96 L168,96 L168,112 L128,112 L128,96 Z M104,96 L112,96 L112,112 L104,112 L104,96 Z M64,96 L88,96 L88,112 L64,112 L64,96 Z"
+               fill="#78AF9F"
+               id="path17"
+               style="opacity:0.242" />
+            <path
+               d="M196,56 L538,56 L538,80 L196,80 L196,56 Z M92,56 L180,56 L180,80 L92,80 L92,56 Z M28,56 L76,56 L76,80 L28,80 L28,56 Z M0,56 L12,56 L12,80 L0,80 L0,56 Z"
+               fill="#DDA032"
+               id="path18"
+               style="opacity:0.067" />
+            <path
+               d="M228,24 L538,24 L538,40 L228,40 L228,24 Z M164,24 L212,24 L212,40 L164,40 L164,24 Z M116,24 L148,24 L148,40 L116,40 L116,24 Z M84,24 L100,24 L100,40 L84,40 L84,24 Z"
+               fill="#D36E2D"
+               id="path19"
+               style="opacity:0.067" />
+            <path
+               d="M218,3.55271368e-15 L538,3.55271368e-15 L538,8 L218,8 L218,3.55271368e-15 Z M122,3.55271368e-15 L202,3.55271368e-15 L202,8 L122,8 L122,3.55271368e-15 Z M98,3.55271368e-15 L106,3.55271368e-15 L106,8 L98,8 L98,3.55271368e-15 Z M50,3.55271368e-15 L82,3.55271368e-15 L82,8 L50,8 L50,3.55271368e-15 Z"
+               fill="#C13F21"
+               id="path20"
+               style="opacity:0.067" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
…ility

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, please include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

Where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The changelog and some other website pages are hard to read on mobile due to the background image overlapping with text.
I have created an alternative version with reduced opacity to show when on a smaller screen to preserve the website style
while maintaining readability.

See the before and after below:

<img width="334" height="577" alt="Screenshot 2025-11-15 223736" src="https://github.com/user-attachments/assets/8a53ba49-c9ad-4c86-932e-1f9df9d4440a" />
<img width="335" height="595" alt="Screenshot 2025-11-15 223753" src="https://github.com/user-attachments/assets/160b9215-2d15-4233-a22e-c2dc11d7b7c6" />
