### PR TITLE
fix(jsx-email): normalize globby paths for preview command

### DIFF
--- a/packages/jsx-email/src/cli/vite-static.mts
+++ b/packages/jsx-email/src/cli/vite-static.mts
@@ -5,7 +5,7 @@ import { globby } from 'globby';
 import mime from 'mime-types';
 // Note: another tshy problem https://github.com/isaacs/tshy/issues/96
 // @ts-ignore
-import type { PluginOption, ViteDevServer } from 'vite';
+import { normalizePath, type PluginOption, type ViteDevServer } from 'vite';
 
 interface ViteStaticOptions {
   paths: string[];
@@ -52,7 +52,7 @@ interface MiddlwareParams {
 const middleware = async (params: MiddlwareParams) => {
   const { options, server } = params;
   const { paths } = options;
-  const files = await globby(paths);
+  const files = await globby(paths.map((path) => normalizePath(path)));
 
   return () => {
     // Note: another tshy problem https://github.com/isaacs/tshy/issues/96


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `moon run repo:lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary
-->

## Component / Package Name:

This PR contains:

<!-- Please place an 'x' like this [x] in all boxes that apply. -->

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

List any relevant issue numbers:
resolves #364 

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR adds path normalization to `globby` file patterns. Windows paths need to be normalized in order for the preview server to serve static assets.

See #364 for a detailed description.