### PR TITLE
feat(web): setup blocks

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,14 +14,17 @@
     "@astrojs/mdx": "^4.2.0",
     "@astrojs/react": "^4.2.1",
     "@astrojs/starlight": "^0.32.2",
+    "@radix-ui/react-tabs": "^1.1.2",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "astro": "^5.1.5",
     "css-fade": "^1.0.7",
+    "jsx-email": "workspace:*",
     "motion": "^12.5.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "sharp": "^0.32.5"
+    "sharp": "^0.32.5",
+    "shiki": "^3.7.0"
   },
   "devDependencies": {
     "@astrojs/tailwind": "^6.0.0",

--- a/apps/web/src/blocks/articles.tsx
+++ b/apps/web/src/blocks/articles.tsx
@@ -1,0 +1,220 @@
+import { Column, Container, Img, Link, Row, Section, Tailwind, Text, render } from 'jsx-email';
+import React from 'react';
+import { codeToHtml } from 'shiki';
+
+export interface Block {
+  name: string;
+  code: string;
+  codeHtml: string;
+  renderedHtml: string;
+}
+
+// Block 1: Article Card
+const ArticleCard = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="rounded-lg border border-gray-200 overflow-hidden">
+        <Img
+          src="https://images.unsplash.com/photo-1499750310107-5fef28a66643?w=600&h=300&fit=crop"
+          alt="Article thumbnail"
+          width={600}
+          height={300}
+          className="w-full"
+        />
+        <Section className="p-4">
+          <Text className="m-0 text-xs text-gray-500">TECHNOLOGY • 5 MIN READ</Text>
+          <Link href="https://example.com/article" className="no-underline">
+            <Text className="m-0 mt-2 text-lg font-semibold text-gray-900">
+              10 Tips for Building Better Email Templates
+            </Text>
+          </Link>
+          <Text className="m-0 mt-2 text-sm text-gray-600">
+            Learn the best practices for creating responsive, accessible email templates that look
+            great in every inbox.
+          </Text>
+          <Link
+            href="https://example.com/article"
+            className="mt-3 inline-block text-sm font-medium text-blue-600 no-underline"
+          >
+            Read more →
+          </Link>
+        </Section>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const articleCardCode = `import { Container, Img, Link, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+  <Section className="rounded-lg border border-gray-200 overflow-hidden">
+    <Img
+      src="https://example.com/thumbnail.jpg"
+      alt="Article thumbnail"
+      width={600}
+      height={300}
+      className="w-full"
+    />
+    <Section className="p-4">
+      <Text className="m-0 text-xs text-gray-500">TECHNOLOGY • 5 MIN READ</Text>
+      <Link href="https://example.com/article" className="no-underline">
+        <Text className="m-0 mt-2 text-lg font-semibold text-gray-900">
+          10 Tips for Building Better Email Templates
+        </Text>
+      </Link>
+      <Text className="m-0 mt-2 text-sm text-gray-600">
+        Learn the best practices for creating responsive, accessible email templates.
+      </Text>
+      <Link
+        href="https://example.com/article"
+        className="mt-3 inline-block text-sm font-medium text-blue-600 no-underline"
+      >
+        Read more →
+      </Link>
+    </Section>
+  </Section>
+  </Container>
+</Tailwind>`;
+
+// Block 2: Article List
+const ArticleList = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section>
+        {/* Article 1 */}
+        <Row className="border-b border-gray-200 py-4">
+          <Column className="w-24 align-middle">
+            <Img
+              src="https://images.unsplash.com/photo-1432821596592-e2c18b78144f?w=100&h=100&fit=crop"
+              alt="Article 1"
+              width={80}
+              height={80}
+              className="rounded-lg"
+            />
+          </Column>
+          <Column className="pl-4 align-middle">
+            <Text className="m-0 text-xs text-gray-500">Mar 15, 2024</Text>
+            <Link href="https://example.com/article-1" className="no-underline">
+              <Text className="m-0 text-sm font-semibold text-gray-900">
+                Getting Started with Email Design
+              </Text>
+            </Link>
+            <Text className="m-0 text-xs text-gray-600">
+              A beginner's guide to creating beautiful email templates.
+            </Text>
+          </Column>
+        </Row>
+        {/* Article 2 */}
+        <Row className="border-b border-gray-200 py-4">
+          <Column className="w-24 align-middle">
+            <Img
+              src="https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=100&h=100&fit=crop"
+              alt="Article 2"
+              width={80}
+              height={80}
+              className="rounded-lg"
+            />
+          </Column>
+          <Column className="pl-4 align-middle">
+            <Text className="m-0 text-xs text-gray-500">Mar 12, 2024</Text>
+            <Link href="https://example.com/article-2" className="no-underline">
+              <Text className="m-0 text-sm font-semibold text-gray-900">
+                Advanced Layout Techniques
+              </Text>
+            </Link>
+            <Text className="m-0 text-xs text-gray-600">
+              Master complex email layouts with these pro tips.
+            </Text>
+          </Column>
+        </Row>
+        {/* Article 3 */}
+        <Row className="py-4">
+          <Column className="w-24 align-middle">
+            <Img
+              src="https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=100&h=100&fit=crop"
+              alt="Article 3"
+              width={80}
+              height={80}
+              className="rounded-lg"
+            />
+          </Column>
+          <Column className="pl-4 align-middle">
+            <Text className="m-0 text-xs text-gray-500">Mar 10, 2024</Text>
+            <Link href="https://example.com/article-3" className="no-underline">
+              <Text className="m-0 text-sm font-semibold text-gray-900">
+                Responsive Email Best Practices
+              </Text>
+            </Link>
+            <Text className="m-0 text-xs text-gray-600">
+              Ensure your emails look great on any device.
+            </Text>
+          </Column>
+        </Row>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const articleListCode = `import { Column, Container, Img, Link, Row, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+  <Section>
+    <Row className="border-b border-gray-200 py-4">
+      <Column className="w-24 align-middle">
+        <Img
+          src="https://example.com/thumb.jpg"
+          alt="Article"
+          width={80}
+          height={80}
+          className="rounded-lg"
+        />
+      </Column>
+      <Column className="pl-4 align-middle">
+        <Text className="m-0 text-xs text-gray-500">Mar 15, 2024</Text>
+        <Link href="https://example.com/article" className="no-underline">
+          <Text className="m-0 text-sm font-semibold text-gray-900">
+            Getting Started with Email Design
+          </Text>
+        </Link>
+        <Text className="m-0 mt-1 text-xs text-gray-600">
+          A beginner's guide to creating beautiful email templates.
+        </Text>
+      </Column>
+    </Row>
+    {/* Repeat for more articles */}
+  </Section>
+  </Container>
+</Tailwind>`;
+
+// Helper to render a component to HTML
+async function renderBlock(Component: React.FC): Promise<string> {
+  return await render(<Component />);
+}
+
+// Helper to highlight code with Shiki
+async function highlightCode(code: string): Promise<string> {
+  return await codeToHtml(code, {
+    lang: 'tsx',
+    theme: 'github-dark'
+  });
+}
+
+// Export function to get all rendered blocks
+export async function getRenderedBlocks(): Promise<Block[]> {
+  return [
+    {
+      name: 'Article Card',
+      code: articleCardCode,
+      codeHtml: await highlightCode(articleCardCode),
+      renderedHtml: await renderBlock(ArticleCard)
+    },
+    {
+      name: 'Article List',
+      code: articleListCode,
+      codeHtml: await highlightCode(articleListCode),
+      renderedHtml: await renderBlock(ArticleList)
+    }
+  ];
+}

--- a/apps/web/src/blocks/avatars.tsx
+++ b/apps/web/src/blocks/avatars.tsx
@@ -1,4 +1,4 @@
-import { Column, Img, Row, Text, render } from 'jsx-email';
+import { Column, Container, Img, Row, Tailwind, Text, render } from 'jsx-email';
 import React from 'react';
 import { codeToHtml } from 'shiki';
 
@@ -11,141 +11,173 @@ export interface Block {
 
 // Pattern 1: Basic Circular Avatar
 const BasicCircularAvatar = () => (
-  <Img
-    src="https://i.pravatar.cc/96?u=john"
-    alt="John Doe"
-    width={48}
-    height={48}
-    style={{
-      borderRadius: '50%',
-      display: 'inline-block',
-      verticalAlign: 'middle'
-    }}
-  />
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Img
+        src="https://i.pravatar.cc/96?u=john"
+        alt="John Doe"
+        width={48}
+        height={48}
+        style={{
+          borderRadius: '50%',
+          display: 'inline-block',
+          verticalAlign: 'middle'
+        }}
+      />
+    </Container>
+  </Tailwind>
 );
 
-const basicCircularAvatarCode = `import { Img } from 'jsx-email';
+const basicCircularAvatarCode = `import { Container, Img, Tailwind } from 'jsx-email';
 
-<Img
-  src="https://example.com/avatar.jpg"
-  alt="John Doe"
-  width={48}
-  height={48}
-  style={{
-    borderRadius: '50%',
-    display: 'inline-block',
-    verticalAlign: 'middle'
-  }}
-/>`;
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Img
+      src="https://example.com/avatar.jpg"
+      alt="John Doe"
+      width={48}
+      height={48}
+      style={{
+        borderRadius: '50%',
+        display: 'inline-block',
+        verticalAlign: 'middle'
+      }}
+    />
+  </Container>
+</Tailwind>`;
 
 // Pattern 2: Rounded Avatar
 const RoundedAvatar = () => (
-  <Img
-    src="https://i.pravatar.cc/96?u=sarah"
-    alt="Sarah Smith"
-    width={48}
-    height={48}
-    style={{
-      borderRadius: 8,
-      display: 'inline-block',
-      verticalAlign: 'middle'
-    }}
-  />
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Img
+        src="https://i.pravatar.cc/96?u=sarah"
+        alt="Sarah Smith"
+        width={48}
+        height={48}
+        style={{
+          borderRadius: 8,
+          display: 'inline-block',
+          verticalAlign: 'middle'
+        }}
+      />
+    </Container>
+  </Tailwind>
 );
 
-const roundedAvatarCode = `import { Img } from 'jsx-email';
+const roundedAvatarCode = `import { Container, Img, Tailwind } from 'jsx-email';
 
-<Img
-  src="https://example.com/avatar.jpg"
-  alt="Sarah Smith"
-  width={48}
-  height={48}
-  style={{
-    borderRadius: 8,
-    display: 'inline-block',
-    verticalAlign: 'middle'
-  }}
-/>`;
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Img
+      src="https://example.com/avatar.jpg"
+      alt="Sarah Smith"
+      width={48}
+      height={48}
+      style={{
+        borderRadius: 8,
+        display: 'inline-block',
+        verticalAlign: 'middle'
+      }}
+    />
+  </Container>
+</Tailwind>`;
 
 // Pattern 3: Avatar with Name
 const AvatarWithName = () => (
-  <Row>
-    <Column style={{ width: 48, verticalAlign: 'middle' }}>
-      <Img
-        src="https://i.pravatar.cc/96?u=jane"
-        alt="Jane Doe"
-        width={48}
-        height={48}
-        style={{ borderRadius: '50%' }}
-      />
-    </Column>
-    <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
-      <Text style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>Jane Doe</Text>
-    </Column>
-  </Row>
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Row>
+        <Column style={{ width: 48, verticalAlign: 'middle' }}>
+          <Img
+            src="https://i.pravatar.cc/96?u=jane"
+            alt="Jane Doe"
+            width={48}
+            height={48}
+            style={{ borderRadius: '50%' }}
+          />
+        </Column>
+        <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
+          <Text style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>Jane Doe</Text>
+        </Column>
+      </Row>
+    </Container>
+  </Tailwind>
 );
 
-const avatarWithNameCode = `import { Row, Column, Img, Text } from 'jsx-email';
+const avatarWithNameCode = `import { Column, Container, Img, Row, Tailwind, Text } from 'jsx-email';
 
-<Row>
-  <Column style={{ width: 48, verticalAlign: 'middle' }}>
-    <Img
-      src="https://example.com/avatar.jpg"
-      alt="Jane Doe"
-      width={48}
-      height={48}
-      style={{ borderRadius: '50%' }}
-    />
-  </Column>
-  <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
-    <Text style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>
-      Jane Doe
-    </Text>
-  </Column>
-</Row>`;
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Row>
+      <Column style={{ width: 48, verticalAlign: 'middle' }}>
+        <Img
+          src="https://example.com/avatar.jpg"
+          alt="Jane Doe"
+          width={48}
+          height={48}
+          style={{ borderRadius: '50%' }}
+        />
+      </Column>
+      <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
+        <Text style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>
+          Jane Doe
+        </Text>
+      </Column>
+    </Row>
+  </Container>
+</Tailwind>`;
 
 // Pattern 4: Avatar with Name and Description
 const AvatarWithDescription = () => (
-  <Row>
-    <Column style={{ width: 48, verticalAlign: 'middle' }}>
-      <Img
-        src="https://i.pravatar.cc/96?u=mike"
-        alt="Mike Johnson"
-        width={48}
-        height={48}
-        style={{ borderRadius: '50%' }}
-      />
-    </Column>
-    <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
-      <Text style={{ margin: 0, fontSize: 14, fontWeight: 600, color: '#111827' }}>
-        Mike Johnson
-      </Text>
-      <Text style={{ margin: 0, fontSize: 12, color: '#6b7280' }}>Software Engineer</Text>
-    </Column>
-  </Row>
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Row>
+        <Column style={{ width: 48, verticalAlign: 'middle' }}>
+          <Img
+            src="https://i.pravatar.cc/96?u=mike"
+            alt="Mike Johnson"
+            width={48}
+            height={48}
+            style={{ borderRadius: '50%' }}
+          />
+        </Column>
+        <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
+          <Text style={{ margin: 0, fontSize: 14, fontWeight: 600, color: '#111827' }}>
+            Mike Johnson
+          </Text>
+          <Text style={{ margin: 0, fontSize: 12, color: '#6b7280' }}>Software Engineer</Text>
+        </Column>
+      </Row>
+    </Container>
+  </Tailwind>
 );
 
-const avatarWithDescriptionCode = `import { Row, Column, Img, Text } from 'jsx-email';
+const avatarWithDescriptionCode = `import { Column, Container, Img, Row, Tailwind, Text } from 'jsx-email';
 
-<Row>
-  <Column style={{ width: 48, verticalAlign: 'middle' }}>
-    <Img
-      src="https://example.com/avatar.jpg"
-      alt="Mike Johnson"
-      width={48}
-      height={48}
-      style={{ borderRadius: '50%' }}
-    />
-  </Column>
-  <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
-    <Text style={{ margin: 0, fontSize: 14, fontWeight: 600, color: '#111827' }}>
-      Mike Johnson
-    </Text>
-    <Text style={{ margin: 0, fontSize: 12, color: '#6b7280' }}>
-      Software Engineer
-    </Text>
-  </Column>
-</Row>`;
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Row>
+      <Column style={{ width: 48, verticalAlign: 'middle' }}>
+        <Img
+          src="https://example.com/avatar.jpg"
+          alt="Mike Johnson"
+          width={48}
+          height={48}
+          style={{ borderRadius: '50%' }}
+        />
+      </Column>
+      <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
+        <Text style={{ margin: 0, fontSize: 14, fontWeight: 600, color: '#111827' }}>
+          Mike Johnson
+        </Text>
+        <Text style={{ margin: 0, fontSize: 12, color: '#6b7280' }}>
+          Software Engineer
+        </Text>
+      </Column>
+    </Row>
+  </Container>
+</Tailwind>`;
 
 // Helper to render a component to HTML
 async function renderBlock(Component: React.FC): Promise<string> {

--- a/apps/web/src/blocks/avatars.tsx
+++ b/apps/web/src/blocks/avatars.tsx
@@ -1,0 +1,191 @@
+import { Column, Img, Row, Text, render } from 'jsx-email';
+import React from 'react';
+import { codeToHtml } from 'shiki';
+
+export interface Block {
+  name: string;
+  code: string;
+  codeHtml: string;
+  renderedHtml: string;
+}
+
+// Pattern 1: Basic Circular Avatar
+const BasicCircularAvatar = () => (
+  <Img
+    src="https://i.pravatar.cc/96?u=john"
+    alt="John Doe"
+    width={48}
+    height={48}
+    style={{
+      borderRadius: '50%',
+      display: 'inline-block',
+      verticalAlign: 'middle'
+    }}
+  />
+);
+
+const basicCircularAvatarCode = `import { Img } from 'jsx-email';
+
+<Img
+  src="https://example.com/avatar.jpg"
+  alt="John Doe"
+  width={48}
+  height={48}
+  style={{
+    borderRadius: '50%',
+    display: 'inline-block',
+    verticalAlign: 'middle'
+  }}
+/>`;
+
+// Pattern 2: Rounded Avatar
+const RoundedAvatar = () => (
+  <Img
+    src="https://i.pravatar.cc/96?u=sarah"
+    alt="Sarah Smith"
+    width={48}
+    height={48}
+    style={{
+      borderRadius: 8,
+      display: 'inline-block',
+      verticalAlign: 'middle'
+    }}
+  />
+);
+
+const roundedAvatarCode = `import { Img } from 'jsx-email';
+
+<Img
+  src="https://example.com/avatar.jpg"
+  alt="Sarah Smith"
+  width={48}
+  height={48}
+  style={{
+    borderRadius: 8,
+    display: 'inline-block',
+    verticalAlign: 'middle'
+  }}
+/>`;
+
+// Pattern 3: Avatar with Name
+const AvatarWithName = () => (
+  <Row>
+    <Column style={{ width: 48, verticalAlign: 'middle' }}>
+      <Img
+        src="https://i.pravatar.cc/96?u=jane"
+        alt="Jane Doe"
+        width={48}
+        height={48}
+        style={{ borderRadius: '50%' }}
+      />
+    </Column>
+    <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
+      <Text style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>Jane Doe</Text>
+    </Column>
+  </Row>
+);
+
+const avatarWithNameCode = `import { Row, Column, Img, Text } from 'jsx-email';
+
+<Row>
+  <Column style={{ width: 48, verticalAlign: 'middle' }}>
+    <Img
+      src="https://example.com/avatar.jpg"
+      alt="Jane Doe"
+      width={48}
+      height={48}
+      style={{ borderRadius: '50%' }}
+    />
+  </Column>
+  <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
+    <Text style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>
+      Jane Doe
+    </Text>
+  </Column>
+</Row>`;
+
+// Pattern 4: Avatar with Name and Description
+const AvatarWithDescription = () => (
+  <Row>
+    <Column style={{ width: 48, verticalAlign: 'middle' }}>
+      <Img
+        src="https://i.pravatar.cc/96?u=mike"
+        alt="Mike Johnson"
+        width={48}
+        height={48}
+        style={{ borderRadius: '50%' }}
+      />
+    </Column>
+    <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
+      <Text style={{ margin: 0, fontSize: 14, fontWeight: 600, color: '#111827' }}>
+        Mike Johnson
+      </Text>
+      <Text style={{ margin: 0, fontSize: 12, color: '#6b7280' }}>Software Engineer</Text>
+    </Column>
+  </Row>
+);
+
+const avatarWithDescriptionCode = `import { Row, Column, Img, Text } from 'jsx-email';
+
+<Row>
+  <Column style={{ width: 48, verticalAlign: 'middle' }}>
+    <Img
+      src="https://example.com/avatar.jpg"
+      alt="Mike Johnson"
+      width={48}
+      height={48}
+      style={{ borderRadius: '50%' }}
+    />
+  </Column>
+  <Column style={{ paddingLeft: 12, verticalAlign: 'middle' }}>
+    <Text style={{ margin: 0, fontSize: 14, fontWeight: 600, color: '#111827' }}>
+      Mike Johnson
+    </Text>
+    <Text style={{ margin: 0, fontSize: 12, color: '#6b7280' }}>
+      Software Engineer
+    </Text>
+  </Column>
+</Row>`;
+
+// Helper to render a component to HTML
+async function renderBlock(Component: React.FC): Promise<string> {
+  return await render(<Component />);
+}
+
+// Helper to highlight code with Shiki
+async function highlightCode(code: string): Promise<string> {
+  return await codeToHtml(code, {
+    lang: 'tsx',
+    theme: 'github-dark'
+  });
+}
+
+// Export function to get all rendered blocks
+export async function getRenderedBlocks(): Promise<Block[]> {
+  return [
+    {
+      name: 'Basic Circular Avatar',
+      code: basicCircularAvatarCode,
+      codeHtml: await highlightCode(basicCircularAvatarCode),
+      renderedHtml: await renderBlock(BasicCircularAvatar)
+    },
+    {
+      name: 'Rounded Avatar',
+      code: roundedAvatarCode,
+      codeHtml: await highlightCode(roundedAvatarCode),
+      renderedHtml: await renderBlock(RoundedAvatar)
+    },
+    {
+      name: 'Avatar with Name',
+      code: avatarWithNameCode,
+      codeHtml: await highlightCode(avatarWithNameCode),
+      renderedHtml: await renderBlock(AvatarWithName)
+    },
+    {
+      name: 'Avatar with Name and Description',
+      code: avatarWithDescriptionCode,
+      codeHtml: await highlightCode(avatarWithDescriptionCode),
+      renderedHtml: await renderBlock(AvatarWithDescription)
+    }
+  ];
+}

--- a/apps/web/src/blocks/ecommerce-pricing.tsx
+++ b/apps/web/src/blocks/ecommerce-pricing.tsx
@@ -1,0 +1,314 @@
+import { Button, Column, Container, Row, Section, Tailwind, Text, render } from 'jsx-email';
+import React from 'react';
+import { codeToHtml } from 'shiki';
+
+export interface Block {
+  name: string;
+  code: string;
+  codeHtml: string;
+  renderedHtml: string;
+}
+
+// Block 1: Product Price Card
+const ProductPriceCard = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="rounded-lg border border-gray-200 bg-white p-6 text-center">
+        <Text className="m-0 text-xs font-semibold uppercase tracking-wide text-green-600">
+          Limited Time Offer
+        </Text>
+        <Text className="m-0 mt-4 text-4xl font-bold text-gray-900">$79</Text>
+        <Text className="m-0 text-sm text-gray-500">
+          <span style={{ textDecoration: 'line-through' }}>$99</span> — Save 20%
+        </Text>
+        <Text className="m-0 mt-4 text-sm text-gray-600">
+          Includes lifetime access and free updates
+        </Text>
+        <Section className="mt-6">
+          <Button
+            href="https://example.com/buy"
+            width={200}
+            height={48}
+            align="center"
+            backgroundColor="#16a34a"
+            borderRadius={8}
+            textColor="#ffffff"
+            fontSize={16}
+          >
+            Buy Now
+          </Button>
+        </Section>
+        <Text className="m-0 mt-4 text-xs text-gray-400">30-day money-back guarantee</Text>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const productPriceCardCode = `import { Button, Container, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Section className="rounded-lg border border-gray-200 bg-white p-6 text-center">
+      <Text className="m-0 text-xs font-semibold uppercase tracking-wide text-green-600">
+        Limited Time Offer
+      </Text>
+      <Text className="m-0 mt-4 text-4xl font-bold text-gray-900">$79</Text>
+      <Text className="m-0 text-sm text-gray-500">
+        <span style={{ textDecoration: 'line-through' }}>$99</span> — Save 20%
+      </Text>
+      <Text className="m-0 mt-4 text-sm text-gray-600">
+        Includes lifetime access and free updates
+      </Text>
+      <Section className="mt-6">
+        <Button
+          href="https://example.com/buy"
+          width={200}
+          height={48}
+          align="center"
+          backgroundColor="#16a34a"
+          borderRadius={8}
+          textColor="#ffffff"
+          fontSize={16}
+        >
+          Buy Now
+        </Button>
+      </Section>
+      <Text className="m-0 mt-4 text-xs text-gray-400">30-day money-back guarantee</Text>
+    </Section>
+  </Container>
+</Tailwind>`;
+
+// Block 2: Pricing Comparison
+const PricingComparison = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Row className="w-full">
+        {/* Basic Plan */}
+        <Column className="w-1/2 p-2 align-top">
+          <Section className="rounded-lg border border-gray-200 bg-white p-5">
+            <Text className="m-0 text-lg font-semibold text-gray-900">Starter</Text>
+            <Text className="m-0 mt-1 text-sm text-gray-500">For individuals</Text>
+            <Text className="m-0 mt-4">
+              <span className="text-3xl font-bold text-gray-900">$9</span>
+              <span className="text-sm text-gray-500">/month</span>
+            </Text>
+            <Section className="mt-4">
+              <Row>
+                <Column className="w-5 align-top">
+                  <Text className="m-0 text-green-500">✓</Text>
+                </Column>
+                <Column className="align-top">
+                  <Text className="m-0 text-sm text-gray-600">5 projects</Text>
+                </Column>
+              </Row>
+              <Row>
+                <Column className="w-5 align-top">
+                  <Text className="m-0 text-green-500">✓</Text>
+                </Column>
+                <Column className="align-top">
+                  <Text className="m-0 text-sm text-gray-600">10GB storage</Text>
+                </Column>
+              </Row>
+              <Row>
+                <Column className="w-5 align-top">
+                  <Text className="m-0 text-green-500">✓</Text>
+                </Column>
+                <Column className="align-top">
+                  <Text className="m-0 text-sm text-gray-600">Email support</Text>
+                </Column>
+              </Row>
+            </Section>
+            <Section className="mt-5">
+              <Button
+                href="https://example.com/starter"
+                width={140}
+                height={40}
+                align="center"
+                backgroundColor="#ffffff"
+                borderRadius={6}
+                textColor="#374151"
+                fontSize={14}
+              >
+                Get Started
+              </Button>
+            </Section>
+          </Section>
+        </Column>
+        {/* Pro Plan */}
+        <Column className="w-1/2 p-2 align-top">
+          <Section className="rounded-lg border-2 border-blue-600 bg-blue-50 p-5">
+            <Row>
+              <Column>
+                <Text className="m-0 text-lg font-semibold text-gray-900">Pro</Text>
+              </Column>
+              <Column className="text-right">
+                <Text className="m-0 rounded-full bg-blue-600 px-2 py-1 text-xs font-medium text-white">
+                  Popular
+                </Text>
+              </Column>
+            </Row>
+            <Text className="m-0 mt-1 text-sm text-gray-500">For teams</Text>
+            <Text className="m-0 mt-4">
+              <span className="text-3xl font-bold text-gray-900">$29</span>
+              <span className="text-sm text-gray-500">/month</span>
+            </Text>
+            <Section className="mt-4">
+              <Row>
+                <Column className="w-5 align-top">
+                  <Text className="m-0 text-green-500">✓</Text>
+                </Column>
+                <Column className="align-top">
+                  <Text className="m-0 text-sm text-gray-600">Unlimited projects</Text>
+                </Column>
+              </Row>
+              <Row>
+                <Column className="w-5 align-top">
+                  <Text className="m-0 text-green-500">✓</Text>
+                </Column>
+                <Column className="align-top">
+                  <Text className="m-0 text-sm text-gray-600">100GB storage</Text>
+                </Column>
+              </Row>
+              <Row>
+                <Column className="w-5 align-top">
+                  <Text className="m-0 text-green-500">✓</Text>
+                </Column>
+                <Column className="align-top">
+                  <Text className="m-0 text-sm text-gray-600">Priority support</Text>
+                </Column>
+              </Row>
+              <Row>
+                <Column className="w-5 align-top">
+                  <Text className="m-0 text-green-500">✓</Text>
+                </Column>
+                <Column className="align-top">
+                  <Text className="m-0 text-sm text-gray-600">Advanced analytics</Text>
+                </Column>
+              </Row>
+            </Section>
+            <Section className="mt-5">
+              <Button
+                href="https://example.com/pro"
+                width={140}
+                height={40}
+                align="center"
+                backgroundColor="#2563eb"
+                borderRadius={6}
+                textColor="#ffffff"
+                fontSize={14}
+              >
+                Upgrade to Pro
+              </Button>
+            </Section>
+          </Section>
+        </Column>
+      </Row>
+    </Container>
+  </Tailwind>
+);
+
+const pricingComparisonCode = `import { Button, Column, Container, Row, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Row className="w-full">
+    {/* Basic Plan */}
+    <Column className="w-1/2 p-2 align-top">
+      <Section className="rounded-lg border border-gray-200 bg-white p-5">
+        <Text className="m-0 text-lg font-semibold text-gray-900">Starter</Text>
+        <Text className="m-0 mt-1 text-sm text-gray-500">For individuals</Text>
+        <Text className="m-0 mt-4">
+          <span className="text-3xl font-bold text-gray-900">$9</span>
+          <span className="text-sm text-gray-500">/month</span>
+        </Text>
+        <Section className="mt-4">
+          <Row>
+            <Column className="w-5 align-top">
+              <Text className="m-0 text-green-500">✓</Text>
+            </Column>
+            <Column className="align-top">
+              <Text className="m-0 text-sm text-gray-600">5 projects</Text>
+            </Column>
+          </Row>
+          {/* More features... */}
+        </Section>
+        <Section className="mt-5">
+          <Button
+            href="https://example.com/starter"
+            width={140}
+            height={40}
+            align="center"
+            backgroundColor="#ffffff"
+            borderRadius={6}
+            textColor="#374151"
+            fontSize={14}
+          >
+            Get Started
+          </Button>
+        </Section>
+      </Section>
+    </Column>
+    {/* Pro Plan - highlighted */}
+    <Column className="w-1/2 p-2 align-top">
+      <Section className="rounded-lg border-2 border-blue-600 bg-blue-50 p-5">
+        <Row>
+          <Column>
+            <Text className="m-0 text-lg font-semibold text-gray-900">Pro</Text>
+          </Column>
+          <Column className="text-right">
+            <Text className="m-0 rounded-full bg-blue-600 px-2 py-1 text-xs font-medium text-white">
+              Popular
+            </Text>
+          </Column>
+        </Row>
+        {/* Plan details... */}
+        <Section className="mt-5">
+          <Button
+            href="https://example.com/pro"
+            width={140}
+            height={40}
+            align="center"
+            backgroundColor="#2563eb"
+            borderRadius={6}
+            textColor="#ffffff"
+            fontSize={14}
+          >
+            Upgrade to Pro
+          </Button>
+        </Section>
+      </Section>
+    </Column>
+    </Row>
+  </Container>
+</Tailwind>`;
+
+// Helper to render a component to HTML
+async function renderBlock(Component: React.FC): Promise<string> {
+  return await render(<Component />);
+}
+
+// Helper to highlight code with Shiki
+async function highlightCode(code: string): Promise<string> {
+  return await codeToHtml(code, {
+    lang: 'tsx',
+    theme: 'github-dark'
+  });
+}
+
+// Export function to get all rendered blocks
+export async function getRenderedBlocks(): Promise<Block[]> {
+  return [
+    {
+      name: 'Product Price Card',
+      code: productPriceCardCode,
+      codeHtml: await highlightCode(productPriceCardCode),
+      renderedHtml: await renderBlock(ProductPriceCard)
+    },
+    {
+      name: 'Pricing Comparison',
+      code: pricingComparisonCode,
+      codeHtml: await highlightCode(pricingComparisonCode),
+      renderedHtml: await renderBlock(PricingComparison)
+    }
+  ];
+}

--- a/apps/web/src/blocks/feedback.tsx
+++ b/apps/web/src/blocks/feedback.tsx
@@ -1,0 +1,208 @@
+import { Column, Container, Link, Row, Section, Tailwind, Text, render } from 'jsx-email';
+import React from 'react';
+import { codeToHtml } from 'shiki';
+
+export interface Block {
+  name: string;
+  code: string;
+  codeHtml: string;
+  renderedHtml: string;
+}
+
+// Block 1: Star Rating
+const StarRating = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="px-4 py-6 text-center">
+        <Text className="m-0 mb-2 text-sm text-gray-600">How would you rate your experience?</Text>
+        <Row className="mx-auto w-auto">
+          <Column className="px-1">
+            <Link href="https://example.com/rate?stars=1" className="text-2xl no-underline">
+              ⭐
+            </Link>
+          </Column>
+          <Column className="px-1">
+            <Link href="https://example.com/rate?stars=2" className="text-2xl no-underline">
+              ⭐
+            </Link>
+          </Column>
+          <Column className="px-1">
+            <Link href="https://example.com/rate?stars=3" className="text-2xl no-underline">
+              ⭐
+            </Link>
+          </Column>
+          <Column className="px-1">
+            <Link href="https://example.com/rate?stars=4" className="text-2xl no-underline">
+              ⭐
+            </Link>
+          </Column>
+          <Column className="px-1">
+            <Link href="https://example.com/rate?stars=5" className="text-2xl no-underline">
+              ⭐
+            </Link>
+          </Column>
+        </Row>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const starRatingCode = `import { Column, Container, Link, Row, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Section className="px-4 py-6 text-center">
+      <Text className="m-0 mb-2 text-sm text-gray-600">How would you rate your experience?</Text>
+      <Row className="mx-auto w-auto">
+        <Column className="px-1">
+          <Link href="https://example.com/rate?stars=1" className="text-2xl no-underline">
+            ⭐
+          </Link>
+        </Column>
+        <Column className="px-1">
+          <Link href="https://example.com/rate?stars=2" className="text-2xl no-underline">
+            ⭐
+          </Link>
+        </Column>
+        <Column className="px-1">
+          <Link href="https://example.com/rate?stars=3" className="text-2xl no-underline">
+            ⭐
+          </Link>
+        </Column>
+        <Column className="px-1">
+          <Link href="https://example.com/rate?stars=4" className="text-2xl no-underline">
+            ⭐
+          </Link>
+        </Column>
+        <Column className="px-1">
+          <Link href="https://example.com/rate?stars=5" className="text-2xl no-underline">
+            ⭐
+          </Link>
+        </Column>
+      </Row>
+    </Section>
+  </Container>
+</Tailwind>`;
+
+// Block 2: Emoji Feedback
+const EmojiFeedback = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="bg-gray-50 px-4 py-6 text-center">
+        <Text className="m-0 mb-4 text-sm font-medium text-gray-700">
+          How was your experience today?
+        </Text>
+        <Row className="mx-auto w-auto">
+          <Column className="px-3">
+            <Link href="https://example.com/feedback?rating=bad" className="text-3xl no-underline">
+              😞
+            </Link>
+            <Text className="m-0 mt-1 text-xs text-gray-500">Bad</Text>
+          </Column>
+          <Column className="px-3">
+            <Link href="https://example.com/feedback?rating=okay" className="text-3xl no-underline">
+              😐
+            </Link>
+            <Text className="m-0 mt-1 text-xs text-gray-500">Okay</Text>
+          </Column>
+          <Column className="px-3">
+            <Link href="https://example.com/feedback?rating=good" className="text-3xl no-underline">
+              😊
+            </Link>
+            <Text className="m-0 mt-1 text-xs text-gray-500">Good</Text>
+          </Column>
+          <Column className="px-3">
+            <Link
+              href="https://example.com/feedback?rating=great"
+              className="text-3xl no-underline"
+            >
+              😍
+            </Link>
+            <Text className="m-0 mt-1 text-xs text-gray-500">Great</Text>
+          </Column>
+        </Row>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const emojiFeedbackCode = `import { Column, Container, Link, Row, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Section className="bg-gray-50 px-4 py-6 text-center">
+      <Text className="m-0 mb-4 text-sm font-medium text-gray-700">
+        How was your experience today?
+      </Text>
+      <Row className="mx-auto w-auto">
+        <Column className="px-3">
+          <Link
+            href="https://example.com/feedback?rating=bad"
+            className="text-3xl no-underline"
+          >
+            😞
+          </Link>
+          <Text className="m-0 mt-1 text-xs text-gray-500">Bad</Text>
+        </Column>
+        <Column className="px-3">
+          <Link
+            href="https://example.com/feedback?rating=okay"
+            className="text-3xl no-underline"
+          >
+            😐
+          </Link>
+          <Text className="m-0 mt-1 text-xs text-gray-500">Okay</Text>
+        </Column>
+        <Column className="px-3">
+          <Link
+            href="https://example.com/feedback?rating=good"
+            className="text-3xl no-underline"
+          >
+            😊
+          </Link>
+          <Text className="m-0 mt-1 text-xs text-gray-500">Good</Text>
+        </Column>
+        <Column className="px-3">
+          <Link
+            href="https://example.com/feedback?rating=great"
+            className="text-3xl no-underline"
+          >
+            😍
+          </Link>
+          <Text className="m-0 mt-1 text-xs text-gray-500">Great</Text>
+        </Column>
+      </Row>
+    </Section>
+  </Container>
+</Tailwind>`;
+
+// Helper to render a component to HTML
+async function renderBlock(Component: React.FC): Promise<string> {
+  return await render(<Component />);
+}
+
+// Helper to highlight code with Shiki
+async function highlightCode(code: string): Promise<string> {
+  return await codeToHtml(code, {
+    lang: 'tsx',
+    theme: 'github-dark'
+  });
+}
+
+// Export function to get all rendered blocks
+export async function getRenderedBlocks(): Promise<Block[]> {
+  return [
+    {
+      name: 'Star Rating',
+      code: starRatingCode,
+      codeHtml: await highlightCode(starRatingCode),
+      renderedHtml: await renderBlock(StarRating)
+    },
+    {
+      name: 'Emoji Feedback',
+      code: emojiFeedbackCode,
+      codeHtml: await highlightCode(emojiFeedbackCode),
+      renderedHtml: await renderBlock(EmojiFeedback)
+    }
+  ];
+}

--- a/apps/web/src/blocks/gallery.tsx
+++ b/apps/web/src/blocks/gallery.tsx
@@ -1,0 +1,313 @@
+import { Column, Container, Img, Row, Section, Tailwind, render } from 'jsx-email';
+import React from 'react';
+import { codeToHtml } from 'shiki';
+
+export interface Block {
+  name: string;
+  code: string;
+  codeHtml: string;
+  renderedHtml: string;
+}
+
+// Block 1: Single Image
+const SingleImage = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="px-4 py-4">
+        <Img
+          src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=600&h=400&fit=crop"
+          alt="Mountain landscape"
+          width={600}
+          height={400}
+          className="w-full rounded-lg"
+        />
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const singleImageCode = `import { Container, Img, Section, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Section className="px-4 py-4">
+      <Img
+        src="https://example.com/image.jpg"
+        alt="Description"
+        width={600}
+        height={400}
+        className="w-full rounded-lg"
+      />
+    </Section>
+  </Container>
+</Tailwind>`;
+
+// Block 2: Two Column Images
+const TwoColumnImages = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Row className="w-full">
+        <Column className="w-1/2 pr-2">
+          <Img
+            src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=300&h=200&fit=crop"
+            alt="Nature scene 1"
+            width={300}
+            height={200}
+            className="w-full rounded-lg"
+          />
+        </Column>
+        <Column className="w-1/2 pl-2">
+          <Img
+            src="https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?w=300&h=200&fit=crop"
+            alt="Nature scene 2"
+            width={300}
+            height={200}
+            className="w-full rounded-lg"
+          />
+        </Column>
+      </Row>
+    </Container>
+  </Tailwind>
+);
+
+const twoColumnImagesCode = `import { Column, Container, Img, Row, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Row className="w-full">
+      <Column className="w-1/2 pr-2">
+        <Img
+          src="https://example.com/image1.jpg"
+          alt="Image 1"
+          width={300}
+          height={200}
+          className="w-full rounded-lg"
+        />
+      </Column>
+      <Column className="w-1/2 pl-2">
+        <Img
+          src="https://example.com/image2.jpg"
+          alt="Image 2"
+          width={300}
+          height={200}
+          className="w-full rounded-lg"
+        />
+      </Column>
+    </Row>
+  </Container>
+</Tailwind>`;
+
+// Block 3: Three Column Images
+const ThreeColumnImages = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Row className="w-full">
+        <Column className="w-1/3 px-1">
+          <Img
+            src="https://images.unsplash.com/photo-1518837695005-2083093ee35b?w=200&h=200&fit=crop"
+            alt="Ocean view"
+            width={200}
+            height={200}
+            className="w-full rounded-lg"
+          />
+        </Column>
+        <Column className="w-1/3 px-1">
+          <Img
+            src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=200&h=200&fit=crop"
+            alt="Beach"
+            width={200}
+            height={200}
+            className="w-full rounded-lg"
+          />
+        </Column>
+        <Column className="w-1/3 px-1">
+          <Img
+            src="https://images.unsplash.com/photo-1476514525535-07fb3b4ae5f1?w=200&h=200&fit=crop"
+            alt="Lake"
+            width={200}
+            height={200}
+            className="w-full rounded-lg"
+          />
+        </Column>
+      </Row>
+    </Container>
+  </Tailwind>
+);
+
+const threeColumnImagesCode = `import { Column, Container, Img, Row, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Row className="w-full">
+      <Column className="w-1/3 px-1">
+        <Img
+          src="https://example.com/image1.jpg"
+          alt="Image 1"
+          width={200}
+          height={200}
+          className="w-full rounded-lg"
+        />
+      </Column>
+      <Column className="w-1/3 px-1">
+        <Img
+          src="https://example.com/image2.jpg"
+          alt="Image 2"
+          width={200}
+          height={200}
+          className="w-full rounded-lg"
+        />
+      </Column>
+      <Column className="w-1/3 px-1">
+        <Img
+          src="https://example.com/image3.jpg"
+          alt="Image 3"
+          width={200}
+          height={200}
+          className="w-full rounded-lg"
+        />
+      </Column>
+    </Row>
+  </Container>
+</Tailwind>`;
+
+// Block 4: Image Grid (2x2)
+const ImageGrid = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section>
+        <Row className="mb-2 w-full">
+          <Column className="w-1/2 pr-1">
+            <Img
+              src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=300&h=200&fit=crop"
+              alt="Travel 1"
+              width={300}
+              height={200}
+              className="w-full rounded-lg"
+            />
+          </Column>
+          <Column className="w-1/2 pl-1">
+            <Img
+              src="https://images.unsplash.com/photo-1503220317375-aaad61436b1b?w=300&h=200&fit=crop"
+              alt="Travel 2"
+              width={300}
+              height={200}
+              className="w-full rounded-lg"
+            />
+          </Column>
+        </Row>
+        <Row className="w-full">
+          <Column className="w-1/2 pr-1">
+            <Img
+              src="https://images.unsplash.com/photo-1476900543704-4312b78632f8?w=300&h=200&fit=crop"
+              alt="Travel 3"
+              width={300}
+              height={200}
+              className="w-full rounded-lg"
+            />
+          </Column>
+          <Column className="w-1/2 pl-1">
+            <Img
+              src="https://images.unsplash.com/photo-1530789253388-582c481c54b0?w=300&h=200&fit=crop"
+              alt="Travel 4"
+              width={300}
+              height={200}
+              className="w-full rounded-lg"
+            />
+          </Column>
+        </Row>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const imageGridCode = `import { Column, Container, Img, Row, Section, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Section>
+      <Row className="mb-2 w-full">
+        <Column className="w-1/2 pr-1">
+          <Img
+            src="https://example.com/image1.jpg"
+            alt="Image 1"
+            width={300}
+            height={200}
+            className="w-full rounded-lg"
+          />
+        </Column>
+        <Column className="w-1/2 pl-1">
+          <Img
+            src="https://example.com/image2.jpg"
+            alt="Image 2"
+            width={300}
+            height={200}
+            className="w-full rounded-lg"
+          />
+        </Column>
+      </Row>
+      <Row className="w-full">
+        <Column className="w-1/2 pr-1">
+          <Img
+            src="https://example.com/image3.jpg"
+            alt="Image 3"
+            width={300}
+            height={200}
+            className="w-full rounded-lg"
+          />
+        </Column>
+        <Column className="w-1/2 pl-1">
+          <Img
+            src="https://example.com/image4.jpg"
+            alt="Image 4"
+            width={300}
+            height={200}
+            className="w-full rounded-lg"
+          />
+        </Column>
+      </Row>
+    </Section>
+  </Container>
+</Tailwind>`;
+
+// Helper to render a component to HTML
+async function renderBlock(Component: React.FC): Promise<string> {
+  return await render(<Component />);
+}
+
+// Helper to highlight code with Shiki
+async function highlightCode(code: string): Promise<string> {
+  return await codeToHtml(code, {
+    lang: 'tsx',
+    theme: 'github-dark'
+  });
+}
+
+// Export function to get all rendered blocks
+export async function getRenderedBlocks(): Promise<Block[]> {
+  return [
+    {
+      name: 'Single Image',
+      code: singleImageCode,
+      codeHtml: await highlightCode(singleImageCode),
+      renderedHtml: await renderBlock(SingleImage)
+    },
+    {
+      name: 'Two Column Images',
+      code: twoColumnImagesCode,
+      codeHtml: await highlightCode(twoColumnImagesCode),
+      renderedHtml: await renderBlock(TwoColumnImages)
+    },
+    {
+      name: 'Three Column Images',
+      code: threeColumnImagesCode,
+      codeHtml: await highlightCode(threeColumnImagesCode),
+      renderedHtml: await renderBlock(ThreeColumnImages)
+    },
+    {
+      name: 'Image Grid',
+      code: imageGridCode,
+      codeHtml: await highlightCode(imageGridCode),
+      renderedHtml: await renderBlock(ImageGrid)
+    }
+  ];
+}

--- a/apps/web/src/blocks/marketing.tsx
+++ b/apps/web/src/blocks/marketing.tsx
@@ -1,0 +1,189 @@
+import { Button, Container, Heading, Section, Tailwind, Text, render } from 'jsx-email';
+import React from 'react';
+import { codeToHtml } from 'shiki';
+
+export interface Block {
+  name: string;
+  code: string;
+  codeHtml: string;
+  renderedHtml: string;
+}
+
+// Block 1: Hero Section
+const HeroSection = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="bg-gray-900 px-6 py-12 text-center">
+        <Heading as="h1" className="m-0 text-3xl font-bold text-white text-center">
+          Welcome to Our Platform
+        </Heading>
+        <Text className="mx-auto mt-4 text-base text-gray-300 text-center">
+          Build beautiful emails with ease. <br /> Our platform helps you create stunning email
+          templates in minutes.
+        </Text>
+        <Button
+          href="https://example.com/get-started"
+          width={160}
+          height={44}
+          align="center"
+          backgroundColor="#2563eb"
+          borderRadius={8}
+          textColor="#ffffff"
+          fontSize={14}
+        >
+          Get Started
+        </Button>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const heroSectionCode = `import { Button, Container, Heading, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Section className="bg-gray-900 px-6 py-12 text-center">
+      <Heading as="h1" className="m-0 text-3xl font-bold text-white text-center">
+        Welcome to Our Platform
+      </Heading>
+      <Text className="mx-auto mt-4 max-w-md text-base text-gray-300 text-center">
+        Build beautiful emails with ease. Our platform helps you create stunning email templates in minutes.
+      </Text>
+      <Button
+        href="https://example.com/get-started"
+        width={160}
+        height={44}
+        align="center"
+        backgroundColor="#2563eb"
+        borderRadius={8}
+        textColor="#ffffff"
+        fontSize={14}
+      >
+        Get Started
+      </Button>
+    </Section>
+  </Container>
+</Tailwind>`;
+
+// Block 2: Announcement Banner
+const AnnouncementBanner = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="bg-blue-600 px-4 py-3 text-center">
+        <Text className="m-0 text-sm font-medium text-white">
+          New feature available! Check out our latest update.{' '}
+          <a href="https://example.com/learn-more" className="text-white underline">
+            Learn more &rarr;
+          </a>
+        </Text>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const announcementBannerCode = `import { Container, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Section className="bg-blue-600 px-4 py-3 text-center">
+      <Text className="m-0 text-sm font-medium text-white">
+        New feature available! Check out our latest update.{' '}
+        <a href="https://example.com/learn-more" className="text-white underline">
+          Learn more &rarr;
+        </a>
+      </Text>
+    </Section>
+  </Container>
+</Tailwind>`;
+
+// Block 3: Newsletter CTA
+const NewsletterCta = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="bg-gray-100 px-6 py-8 text-center">
+        <Heading as="h2" className="m-0 text-xl font-bold text-gray-900">
+          Stay in the loop
+        </Heading>
+        <Text className="mt-2 text-sm text-gray-600">
+          Subscribe to our newsletter for the latest updates and tips.
+        </Text>
+        <Button
+          href="https://example.com/subscribe"
+          width={150}
+          height={40}
+          align="center"
+          backgroundColor="#111827"
+          borderRadius={6}
+          textColor="#ffffff"
+          fontSize={14}
+        >
+          Subscribe Now
+        </Button>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const newsletterCtaCode = `import { Button, Container, Heading, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Section className="bg-gray-100 px-6 py-8 text-center">
+      <Heading as="h2" className="m-0 text-xl font-bold text-gray-900">
+        Stay in the loop
+      </Heading>
+      <Text className="mt-2 text-sm text-gray-600">
+        Subscribe to our newsletter for the latest updates and tips.
+      </Text>
+      <Button
+        href="https://example.com/subscribe"
+        width={150}
+        height={40}
+        align="center"
+        backgroundColor="#111827"
+        borderRadius={6}
+        textColor="#ffffff"
+        fontSize={14}
+      >
+        Subscribe Now
+      </Button>
+    </Section>
+  </Container>
+</Tailwind>`;
+
+// Helper to render a component to HTML
+async function renderBlock(Component: React.FC): Promise<string> {
+  return await render(<Component />);
+}
+
+// Helper to highlight code with Shiki
+async function highlightCode(code: string): Promise<string> {
+  return await codeToHtml(code, {
+    lang: 'tsx',
+    theme: 'github-dark'
+  });
+}
+
+// Export function to get all rendered blocks
+export async function getRenderedBlocks(): Promise<Block[]> {
+  return [
+    {
+      name: 'Hero Section',
+      code: heroSectionCode,
+      codeHtml: await highlightCode(heroSectionCode),
+      renderedHtml: await renderBlock(HeroSection)
+    },
+    {
+      name: 'Announcement Banner',
+      code: announcementBannerCode,
+      codeHtml: await highlightCode(announcementBannerCode),
+      renderedHtml: await renderBlock(AnnouncementBanner)
+    },
+    {
+      name: 'Newsletter CTA',
+      code: newsletterCtaCode,
+      codeHtml: await highlightCode(newsletterCtaCode),
+      renderedHtml: await renderBlock(NewsletterCta)
+    }
+  ];
+}

--- a/apps/web/src/blocks/surveys.tsx
+++ b/apps/web/src/blocks/surveys.tsx
@@ -1,0 +1,611 @@
+import { Container, Heading, Link, Section, Tailwind, Text, render } from 'jsx-email';
+import React from 'react';
+import { codeToHtml } from 'shiki';
+
+export interface Block {
+  name: string;
+  code: string;
+  codeHtml: string;
+  renderedHtml: string;
+}
+
+// Block 1: Satisfaction Survey - Filled indigo buttons
+const SatisfactionSurvey = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="rounded-2xl bg-white px-10 py-10">
+        <Heading as="h2" className="m-0 text-xl font-bold text-gray-900">
+          How satisfied were you overall with the initial conversation about your claim?
+        </Heading>
+        <Text className="m-0 mt-3 text-sm text-gray-500">
+          Your feedback is important to us and it will be used to better serve our customers.
+        </Text>
+        <Section className="mt-10">
+          <table cellPadding="0" cellSpacing="0" style={{ margin: '0 auto' }}>
+            <tr>
+              <td style={{ paddingRight: '60px' }}>
+                <Text className="m-0 text-xs text-gray-400">Dissatisfied</Text>
+              </td>
+              <td style={{ paddingLeft: '60px', textAlign: 'right' }}>
+                <Text className="m-0 text-xs text-gray-400">Satisfied</Text>
+              </td>
+            </tr>
+          </table>
+          <table cellPadding="0" cellSpacing="0" style={{ margin: '8px auto 0' }}>
+            <tr>
+              <td style={{ padding: '0 3px' }}>
+                <Link
+                  href="https://example.com/rate?score=1"
+                  style={{
+                    display: 'inline-block',
+                    width: '44px',
+                    height: '44px',
+                    lineHeight: '44px',
+                    backgroundColor: '#6366f1',
+                    borderRadius: '8px',
+                    textAlign: 'center',
+                    color: '#ffffff',
+                    fontSize: '16px',
+                    fontWeight: '500',
+                    textDecoration: 'none'
+                  }}
+                >
+                  1
+                </Link>
+              </td>
+              <td style={{ padding: '0 3px' }}>
+                <Link
+                  href="https://example.com/rate?score=2"
+                  style={{
+                    display: 'inline-block',
+                    width: '44px',
+                    height: '44px',
+                    lineHeight: '44px',
+                    backgroundColor: '#6366f1',
+                    borderRadius: '8px',
+                    textAlign: 'center',
+                    color: '#ffffff',
+                    fontSize: '16px',
+                    fontWeight: '500',
+                    textDecoration: 'none'
+                  }}
+                >
+                  2
+                </Link>
+              </td>
+              <td style={{ padding: '0 3px' }}>
+                <Link
+                  href="https://example.com/rate?score=3"
+                  style={{
+                    display: 'inline-block',
+                    width: '44px',
+                    height: '44px',
+                    lineHeight: '44px',
+                    backgroundColor: '#6366f1',
+                    borderRadius: '8px',
+                    textAlign: 'center',
+                    color: '#ffffff',
+                    fontSize: '16px',
+                    fontWeight: '500',
+                    textDecoration: 'none'
+                  }}
+                >
+                  3
+                </Link>
+              </td>
+              <td style={{ padding: '0 3px' }}>
+                <Link
+                  href="https://example.com/rate?score=4"
+                  style={{
+                    display: 'inline-block',
+                    width: '44px',
+                    height: '44px',
+                    lineHeight: '44px',
+                    backgroundColor: '#6366f1',
+                    borderRadius: '8px',
+                    textAlign: 'center',
+                    color: '#ffffff',
+                    fontSize: '16px',
+                    fontWeight: '500',
+                    textDecoration: 'none'
+                  }}
+                >
+                  4
+                </Link>
+              </td>
+              <td style={{ padding: '0 3px' }}>
+                <Link
+                  href="https://example.com/rate?score=5"
+                  style={{
+                    display: 'inline-block',
+                    width: '44px',
+                    height: '44px',
+                    lineHeight: '44px',
+                    backgroundColor: '#6366f1',
+                    borderRadius: '8px',
+                    textAlign: 'center',
+                    color: '#ffffff',
+                    fontSize: '16px',
+                    fontWeight: '500',
+                    textDecoration: 'none'
+                  }}
+                >
+                  5
+                </Link>
+              </td>
+            </tr>
+          </table>
+        </Section>
+        <Section className="mt-10 border-t border-gray-200 pt-5">
+          <Text className="m-0 text-center text-xs text-gray-400">
+            Customer Experience Research Team
+          </Text>
+        </Section>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const satisfactionSurveyCode = `import { Container, Link, Heading, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+  <Section className="rounded-2xl bg-white px-10 py-10">
+    <Heading as="h2" className="m-0 text-xl font-bold text-gray-900">
+      How satisfied were you overall with the initial conversation about your claim?
+    </Heading>
+    <Text className="m-0 mt-3 text-sm text-gray-500">
+      Your feedback is important to us and it will be used to better serve our customers.
+    </Text>
+    <Section className="mt-10">
+      <table cellPadding="0" cellSpacing="0" style={{ margin: '0 auto' }}>
+        <tr>
+          <td style={{ paddingRight: '60px' }}>
+            <Text className="m-0 text-xs text-gray-400">Dissatisfied</Text>
+          </td>
+          <td style={{ paddingLeft: '60px', textAlign: 'right' }}>
+            <Text className="m-0 text-xs text-gray-400">Satisfied</Text>
+          </td>
+        </tr>
+      </table>
+      <table cellPadding="0" cellSpacing="0" style={{ margin: '8px auto 0' }}>
+        <tr>
+          <td style={{ padding: '0 3px' }}>
+            <Link href="https://example.com/rate?score=1" style={{
+              display: 'inline-block',
+              width: '44px',
+              height: '44px',
+              lineHeight: '44px',
+              backgroundColor: '#6366f1',
+              borderRadius: '8px',
+              textAlign: 'center',
+              color: '#ffffff',
+              fontSize: '16px',
+              fontWeight: '500',
+              textDecoration: 'none'
+            }}>1</Link>
+          </td>
+          {/* Repeat for 2, 3, 4, 5 */}
+        </tr>
+      </table>
+    </Section>
+    <Section className="mt-10 border-t border-gray-200 pt-5">
+      <Text className="m-0 text-center text-xs text-gray-400">
+        Customer Experience Research Team
+      </Text>
+    </Section>
+  </Section>
+  </Container>
+</Tailwind>`;
+
+// Block 2: Survey Section - Outlined buttons with indigo border
+const SurveySection = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="rounded-2xl bg-white px-10 py-10 text-center">
+        <Text className="m-0 text-sm font-semibold text-indigo-500">Your opinion matters</Text>
+        <Heading as="h2" className="m-0 mt-2 text-2xl font-bold text-gray-900">
+          We want to hear you
+        </Heading>
+        <Text className="m-0 mt-3 text-sm text-gray-500">
+          How would you rate your experience using our product in a scale from 1 to 5?
+        </Text>
+        <table cellPadding="0" cellSpacing="0" style={{ margin: '24px auto 0' }}>
+          <tr>
+            <td style={{ padding: '0 4px' }}>
+              <Link
+                href="https://example.com/rate?score=1"
+                style={{
+                  display: 'inline-block',
+                  width: '40px',
+                  height: '40px',
+                  lineHeight: '38px',
+                  backgroundColor: '#ffffff',
+                  border: '1px solid #6366f1',
+                  borderRadius: '8px',
+                  textAlign: 'center',
+                  color: '#6366f1',
+                  fontSize: '14px',
+                  fontWeight: '500',
+                  textDecoration: 'none'
+                }}
+              >
+                1
+              </Link>
+            </td>
+            <td style={{ padding: '0 4px' }}>
+              <Link
+                href="https://example.com/rate?score=2"
+                style={{
+                  display: 'inline-block',
+                  width: '40px',
+                  height: '40px',
+                  lineHeight: '38px',
+                  backgroundColor: '#ffffff',
+                  border: '1px solid #6366f1',
+                  borderRadius: '8px',
+                  textAlign: 'center',
+                  color: '#6366f1',
+                  fontSize: '14px',
+                  fontWeight: '500',
+                  textDecoration: 'none'
+                }}
+              >
+                2
+              </Link>
+            </td>
+            <td style={{ padding: '0 4px' }}>
+              <Link
+                href="https://example.com/rate?score=3"
+                style={{
+                  display: 'inline-block',
+                  width: '40px',
+                  height: '40px',
+                  lineHeight: '38px',
+                  backgroundColor: '#ffffff',
+                  border: '1px solid #6366f1',
+                  borderRadius: '8px',
+                  textAlign: 'center',
+                  color: '#6366f1',
+                  fontSize: '14px',
+                  fontWeight: '500',
+                  textDecoration: 'none'
+                }}
+              >
+                3
+              </Link>
+            </td>
+            <td style={{ padding: '0 4px' }}>
+              <Link
+                href="https://example.com/rate?score=4"
+                style={{
+                  display: 'inline-block',
+                  width: '40px',
+                  height: '40px',
+                  lineHeight: '38px',
+                  backgroundColor: '#ffffff',
+                  border: '1px solid #6366f1',
+                  borderRadius: '8px',
+                  textAlign: 'center',
+                  color: '#6366f1',
+                  fontSize: '14px',
+                  fontWeight: '500',
+                  textDecoration: 'none'
+                }}
+              >
+                4
+              </Link>
+            </td>
+            <td style={{ padding: '0 4px' }}>
+              <Link
+                href="https://example.com/rate?score=5"
+                style={{
+                  display: 'inline-block',
+                  width: '40px',
+                  height: '40px',
+                  lineHeight: '38px',
+                  backgroundColor: '#ffffff',
+                  border: '1px solid #6366f1',
+                  borderRadius: '8px',
+                  textAlign: 'center',
+                  color: '#6366f1',
+                  fontSize: '14px',
+                  fontWeight: '500',
+                  textDecoration: 'none'
+                }}
+              >
+                5
+              </Link>
+            </td>
+          </tr>
+        </table>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const surveySectionCode = `import { Container, Link, Heading, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+  <Section className="rounded-2xl bg-white px-10 py-10 text-center">
+    <Text className="m-0 text-sm font-semibold text-indigo-500">Your opinion matters</Text>
+    <Heading as="h2" className="m-0 mt-2 text-2xl font-bold text-gray-900">
+      We want to hear you
+    </Heading>
+    <Text className="m-0 mt-3 text-sm text-gray-500">
+      How would you rate your experience using our product in a scale from 1 to 5?
+    </Text>
+    <table cellPadding="0" cellSpacing="0" style={{ margin: '24px auto 0' }}>
+      <tr>
+        <td style={{ padding: '0 4px' }}>
+          <Link href="https://example.com/rate?score=1" style={{
+            display: 'inline-block',
+            width: '40px',
+            height: '40px',
+            lineHeight: '38px',
+            backgroundColor: '#ffffff',
+            border: '1px solid #6366f1',
+            borderRadius: '8px',
+            textAlign: 'center',
+            color: '#6366f1',
+            fontSize: '14px',
+            fontWeight: '500',
+            textDecoration: 'none'
+          }}>1</Link>
+        </td>
+        {/* Repeat for 2, 3, 4, 5 */}
+      </tr>
+    </table>
+  </Section>
+  </Container>
+</Tailwind>`;
+
+// Block 3: Customer Reviews - Progress bars
+const CustomerReviews = () => (
+  <Tailwind>
+    <Section className="mx-auto max-w-[320px] rounded-2xl bg-white px-6 py-8">
+      <Heading as="h2" className="m-0 text-xl font-bold text-gray-900">
+        Customer Reviews
+      </Heading>
+      <Section className="mt-8">
+        {/* 5 stars - 63% */}
+        <table cellPadding="0" cellSpacing="0" style={{ width: '100%', marginBottom: '12px' }}>
+          <tr>
+            <td style={{ width: '24px', verticalAlign: 'middle' }}>
+              <Text className="m-0 text-sm text-gray-600">5</Text>
+            </td>
+            <td style={{ verticalAlign: 'middle', padding: '0 12px' }}>
+              <div
+                style={{
+                  width: '100%',
+                  height: '10px',
+                  backgroundColor: '#e5e7eb',
+                  borderRadius: '999px',
+                  overflow: 'hidden'
+                }}
+              >
+                <div
+                  style={{
+                    width: '63%',
+                    height: '10px',
+                    backgroundColor: '#6366f1',
+                    borderRadius: '999px'
+                  }}
+                />
+              </div>
+            </td>
+            <td style={{ width: '40px', verticalAlign: 'middle', textAlign: 'right' }}>
+              <Text className="m-0 text-sm text-gray-500">63%</Text>
+            </td>
+          </tr>
+        </table>
+        {/* 4 stars - 10% */}
+        <table cellPadding="0" cellSpacing="0" style={{ width: '100%', marginBottom: '12px' }}>
+          <tr>
+            <td style={{ width: '24px', verticalAlign: 'middle' }}>
+              <Text className="m-0 text-sm text-gray-600">4</Text>
+            </td>
+            <td style={{ verticalAlign: 'middle', padding: '0 12px' }}>
+              <div
+                style={{
+                  width: '100%',
+                  height: '10px',
+                  backgroundColor: '#e5e7eb',
+                  borderRadius: '999px',
+                  overflow: 'hidden'
+                }}
+              >
+                <div
+                  style={{
+                    width: '10%',
+                    height: '10px',
+                    backgroundColor: '#6366f1',
+                    borderRadius: '999px'
+                  }}
+                />
+              </div>
+            </td>
+            <td style={{ width: '40px', verticalAlign: 'middle', textAlign: 'right' }}>
+              <Text className="m-0 text-sm text-gray-500">10%</Text>
+            </td>
+          </tr>
+        </table>
+        {/* 3 stars - 6% */}
+        <table cellPadding="0" cellSpacing="0" style={{ width: '100%', marginBottom: '12px' }}>
+          <tr>
+            <td style={{ width: '24px', verticalAlign: 'middle' }}>
+              <Text className="m-0 text-sm text-gray-600">3</Text>
+            </td>
+            <td style={{ verticalAlign: 'middle', padding: '0 12px' }}>
+              <div
+                style={{
+                  width: '100%',
+                  height: '10px',
+                  backgroundColor: '#e5e7eb',
+                  borderRadius: '999px',
+                  overflow: 'hidden'
+                }}
+              >
+                <div
+                  style={{
+                    width: '6%',
+                    height: '10px',
+                    backgroundColor: '#6366f1',
+                    borderRadius: '999px'
+                  }}
+                />
+              </div>
+            </td>
+            <td style={{ width: '40px', verticalAlign: 'middle', textAlign: 'right' }}>
+              <Text className="m-0 text-sm text-gray-500">6%</Text>
+            </td>
+          </tr>
+        </table>
+        {/* 2 stars - 12% */}
+        <table cellPadding="0" cellSpacing="0" style={{ width: '100%', marginBottom: '12px' }}>
+          <tr>
+            <td style={{ width: '24px', verticalAlign: 'middle' }}>
+              <Text className="m-0 text-sm text-gray-600">2</Text>
+            </td>
+            <td style={{ verticalAlign: 'middle', padding: '0 12px' }}>
+              <div
+                style={{
+                  width: '100%',
+                  height: '10px',
+                  backgroundColor: '#e5e7eb',
+                  borderRadius: '999px',
+                  overflow: 'hidden'
+                }}
+              >
+                <div
+                  style={{
+                    width: '12%',
+                    height: '10px',
+                    backgroundColor: '#6366f1',
+                    borderRadius: '999px'
+                  }}
+                />
+              </div>
+            </td>
+            <td style={{ width: '40px', verticalAlign: 'middle', textAlign: 'right' }}>
+              <Text className="m-0 text-sm text-gray-500">12%</Text>
+            </td>
+          </tr>
+        </table>
+        {/* 1 star - 9% */}
+        <table cellPadding="0" cellSpacing="0" style={{ width: '100%' }}>
+          <tr>
+            <td style={{ width: '24px', verticalAlign: 'middle' }}>
+              <Text className="m-0 text-sm text-gray-600">1</Text>
+            </td>
+            <td style={{ verticalAlign: 'middle', padding: '0 12px' }}>
+              <div
+                style={{
+                  width: '100%',
+                  height: '10px',
+                  backgroundColor: '#e5e7eb',
+                  borderRadius: '999px',
+                  overflow: 'hidden'
+                }}
+              >
+                <div
+                  style={{
+                    width: '9%',
+                    height: '10px',
+                    backgroundColor: '#6366f1',
+                    borderRadius: '999px'
+                  }}
+                />
+              </div>
+            </td>
+            <td style={{ width: '40px', verticalAlign: 'middle', textAlign: 'right' }}>
+              <Text className="m-0 text-sm text-gray-500">9%</Text>
+            </td>
+          </tr>
+        </table>
+      </Section>
+      <Text className="m-0 mt-8 text-center text-xs text-gray-400">
+        Based on <strong>1624</strong> Reviews
+      </Text>
+    </Section>
+  </Tailwind>
+);
+
+const customerReviewsCode = `import { Heading, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Section className="mx-auto max-w-[320px] rounded-2xl bg-white px-6 py-8">
+    <Heading as="h2" className="m-0 text-xl font-bold text-gray-900">Customer Reviews</Heading>
+    <Section className="mt-8">
+      {/* Rating row with progress bar */}
+      <table cellPadding="0" cellSpacing="0" style={{ width: '100%', marginBottom: '12px' }}>
+        <tr>
+          <td style={{ width: '24px', verticalAlign: 'middle' }}>
+            <Text className="m-0 text-sm text-gray-600">5</Text>
+          </td>
+          <td style={{ verticalAlign: 'middle', padding: '0 12px' }}>
+            <div style={{
+              width: '100%',
+              height: '10px',
+              backgroundColor: '#e5e7eb',
+              borderRadius: '999px',
+              overflow: 'hidden'
+            }}>
+              <div style={{
+                width: '63%',
+                height: '10px',
+                backgroundColor: '#6366f1',
+                borderRadius: '999px'
+              }} />
+            </div>
+          </td>
+          <td style={{ width: '40px', verticalAlign: 'middle', textAlign: 'right' }}>
+            <Text className="m-0 text-sm text-gray-500">63%</Text>
+          </td>
+        </tr>
+      </table>
+      {/* Repeat for 4, 3, 2, 1 stars */}
+    </Section>
+    <Text className="m-0 mt-8 text-center text-xs text-gray-400">
+      Based on <strong>1624</strong> Reviews
+    </Text>
+  </Section>
+</Tailwind>`;
+
+// Helper to render a component to HTML
+async function renderBlock(Component: React.FC): Promise<string> {
+  return await render(<Component />);
+}
+
+// Helper to highlight code with Shiki
+async function highlightCode(code: string): Promise<string> {
+  return await codeToHtml(code, {
+    lang: 'tsx',
+    theme: 'github-dark'
+  });
+}
+
+// Export function to get all rendered blocks
+export async function getRenderedBlocks(): Promise<Block[]> {
+  return [
+    {
+      name: 'Satisfaction Survey',
+      code: satisfactionSurveyCode,
+      codeHtml: await highlightCode(satisfactionSurveyCode),
+      renderedHtml: await renderBlock(SatisfactionSurvey)
+    },
+    {
+      name: 'Survey Section',
+      code: surveySectionCode,
+      codeHtml: await highlightCode(surveySectionCode),
+      renderedHtml: await renderBlock(SurveySection)
+    },
+    {
+      name: 'Customer Reviews',
+      code: customerReviewsCode,
+      codeHtml: await highlightCode(customerReviewsCode),
+      renderedHtml: await renderBlock(CustomerReviews)
+    }
+  ];
+}

--- a/apps/web/src/blocks/testimonials.tsx
+++ b/apps/web/src/blocks/testimonials.tsx
@@ -1,0 +1,190 @@
+import { Column, Container, Img, Row, Section, Tailwind, Text, render } from 'jsx-email';
+import React from 'react';
+import { codeToHtml } from 'shiki';
+
+export interface Block {
+  name: string;
+  code: string;
+  codeHtml: string;
+  renderedHtml: string;
+}
+
+// Block 1: Testimonial Simple Centered
+const TestimonialSimpleCentered = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="rounded-2xl bg-white px-10 py-12 text-center">
+        <Text className="m-0 text-base leading-relaxed text-gray-700">
+          Design is not just what it looks like and feels like. Design is how it works. The people
+          who are crazy enough to think they can change the world are the ones who do. Innovation
+          distinguishes between a leader and a follower.
+        </Text>
+        <Section className="mt-6">
+          <table cellPadding="0" cellSpacing="0" style={{ margin: '0 auto' }}>
+            <tr>
+              <td style={{ verticalAlign: 'middle', paddingRight: '12px' }}>
+                <Img
+                  src="https://i.pravatar.cc/96?u=ericawang"
+                  alt="Erica Wang"
+                  width={40}
+                  height={40}
+                  style={{ borderRadius: '50%' }}
+                />
+              </td>
+              <td style={{ verticalAlign: 'middle' }}>
+                <Text
+                  className="m-0 text-sm font-semibold text-gray-900"
+                  style={{ display: 'inline' }}
+                >
+                  Erica Wang
+                </Text>
+                <Text className="m-0 text-sm text-gray-500" style={{ display: 'inline' }}>
+                  {' '}
+                  &bull; Co-founder of Circle
+                </Text>
+              </td>
+            </tr>
+          </table>
+        </Section>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const testimonialSimpleCenteredCode = `import { Container, Img, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Section className="rounded-2xl bg-white px-10 py-12 text-center">
+      <Text className="m-0 text-base leading-relaxed text-gray-700">
+        Design is not just what it looks like and feels like. Design is how it works. The people who are crazy enough to think they can change the world are the ones who do. Innovation distinguishes between a leader and a follower.
+      </Text>
+      <Section className="mt-6">
+        <table cellPadding="0" cellSpacing="0" style={{ margin: '0 auto' }}>
+          <tr>
+            <td style={{ verticalAlign: 'middle', paddingRight: '12px' }}>
+              <Img
+                src="https://example.com/avatar.jpg"
+                alt="Erica Wang"
+                width={40}
+                height={40}
+                style={{ borderRadius: '50%' }}
+              />
+            </td>
+            <td style={{ verticalAlign: 'middle' }}>
+              <Text className="m-0 text-sm font-semibold text-gray-900" style={{ display: 'inline' }}>
+                Erica Wang
+              </Text>
+              <Text className="m-0 text-sm text-gray-500" style={{ display: 'inline' }}>
+                {' '}&bull; Co-founder of Circle
+              </Text>
+            </td>
+          </tr>
+        </table>
+      </Section>
+    </Section>
+  </Container>
+</Tailwind>`;
+
+// Block 2: Testimonial with Large Avatar
+const TestimonialWithLargeAvatar = () => (
+  <Tailwind>
+    <Container className="mx-auto max-w-[600px]">
+      <Section className="rounded-2xl bg-white px-10 py-12">
+        <table cellPadding="0" cellSpacing="0" style={{ width: '100%' }}>
+          <tr>
+            <td style={{ width: '180px', verticalAlign: 'top', paddingRight: '24px' }}>
+              <Img
+                src="https://i.pravatar.cc/300?u=ericawang"
+                alt="Erica Wang"
+                width={180}
+                height={220}
+                style={{ objectFit: 'cover', display: 'block', borderRadius: '8px' }}
+              />
+            </td>
+            <td style={{ verticalAlign: 'middle' }}>
+              <Text className="m-0 text-base leading-relaxed text-gray-700">
+                Design is not just what it looks like and feels like. Design is how it works. The
+                people who are crazy enough to think they can change the world are the ones who do.
+                Innovation distinguishes between a leader and a follower.
+              </Text>
+              <Text
+                className="m-0 mt-6 text-sm font-semibold text-gray-900"
+                style={{ marginBottom: '0' }}
+              >
+                Erica Wang
+              </Text>
+              <Text className="m-0 text-sm text-gray-500" style={{ marginTop: '2px' }}>
+                Co-founder of Circle
+              </Text>
+            </td>
+          </tr>
+        </table>
+      </Section>
+    </Container>
+  </Tailwind>
+);
+
+const testimonialWithLargeAvatarCode = `import { Container, Img, Section, Text, Tailwind } from 'jsx-email';
+
+<Tailwind>
+  <Container className="mx-auto max-w-[600px]">
+    <Section className="rounded-2xl bg-white px-10 py-12">
+      <table cellPadding="0" cellSpacing="0" style={{ width: '100%' }}>
+        <tr>
+          <td style={{ width: '180px', verticalAlign: 'top', paddingRight: '24px' }}>
+            <Img
+              src="https://example.com/large-avatar.jpg"
+              alt="Erica Wang"
+              width={180}
+              height={220}
+              style={{ objectFit: 'cover', display: 'block', borderRadius: '8px' }}
+            />
+          </td>
+          <td style={{ verticalAlign: 'middle' }}>
+            <Text className="m-0 text-base leading-relaxed text-gray-700">
+              Design is not just what it looks like and feels like. Design is how it works. The people who are crazy enough to think they can change the world are the ones who do. Innovation distinguishes between a leader and a follower.
+            </Text>
+            <Text className="m-0 mt-6 text-sm font-semibold text-gray-900" style={{ marginBottom: '0' }}>
+              Erica Wang
+            </Text>
+            <Text className="m-0 text-sm text-gray-500" style={{ marginTop: '2px' }}>
+              Co-founder of Circle
+            </Text>
+          </td>
+        </tr>
+      </table>
+    </Section>
+  </Container>
+</Tailwind>`;
+
+// Helper to render a component to HTML
+async function renderBlock(Component: React.FC): Promise<string> {
+  return await render(<Component />);
+}
+
+// Helper to highlight code with Shiki
+async function highlightCode(code: string): Promise<string> {
+  return await codeToHtml(code, {
+    lang: 'tsx',
+    theme: 'github-dark'
+  });
+}
+
+// Export function to get all rendered blocks
+export async function getRenderedBlocks(): Promise<Block[]> {
+  return [
+    {
+      name: 'Testimonial simple centered',
+      code: testimonialSimpleCenteredCode,
+      codeHtml: await highlightCode(testimonialSimpleCenteredCode),
+      renderedHtml: await renderBlock(TestimonialSimpleCentered)
+    },
+    {
+      name: 'Testimonial with large avatar',
+      code: testimonialWithLargeAvatarCode,
+      codeHtml: await highlightCode(testimonialWithLargeAvatarCode),
+      renderedHtml: await renderBlock(TestimonialWithLargeAvatar)
+    }
+  ];
+}

--- a/apps/web/src/components/BlockPreview.tsx
+++ b/apps/web/src/components/BlockPreview.tsx
@@ -1,0 +1,73 @@
+import * as Tabs from '@radix-ui/react-tabs';
+import { useState } from 'react';
+
+interface BlockPreviewProps {
+  name: string;
+  renderedHtml: string;
+  code: string;
+  codeHtml: string;
+  height?: number;
+}
+
+export function BlockPreview({
+  name,
+  renderedHtml,
+  code,
+  codeHtml,
+  height = 200
+}: BlockPreviewProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copyCode = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="block-preview border border-gray-200 dark:border-gray-800 rounded-2xl overflow-hidden mb-8 bg-white dark:bg-black">
+      <Tabs.Root defaultValue="preview" className="flex flex-col">
+        <div className="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-2">
+          <h3 className="font-semibold text-gray-800 dark:text-gray-200 text-sm">{name}</h3>
+          <Tabs.List className="flex gap-1 bg-gray-200 dark:bg-gray-700 rounded-md p-1">
+            <Tabs.Trigger
+              value="preview"
+              className="px-3 py-1 text-xs font-medium rounded transition-colors data-[state=active]:bg-white dark:data-[state=active]:bg-gray-600 data-[state=active]:text-gray-900 dark:data-[state=active]:text-white text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+            >
+              Preview
+            </Tabs.Trigger>
+            <Tabs.Trigger
+              value="code"
+              className="px-3 py-1 text-xs font-medium rounded transition-colors data-[state=active]:bg-white dark:data-[state=active]:bg-gray-600 data-[state=active]:text-gray-900 dark:data-[state=active]:text-white text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+            >
+              Code
+            </Tabs.Trigger>
+          </Tabs.List>
+        </div>
+
+        <div style={{ height }}>
+          <Tabs.Content value="preview" className="p-6 bg-white dark:bg-gray-900 h-full">
+            <iframe
+              srcDoc={`<!DOCTYPE html><html><head><style>body{margin:0;padding:16px;font-family:system-ui,sans-serif;background:#fff;}</style></head><body>${renderedHtml}</body></html>`}
+              className="border-0 w-full h-full bg-white rounded"
+              title={`Preview: ${name}`}
+            />
+          </Tabs.Content>
+
+          <Tabs.Content value="code" className="relative h-full bg-[#24292e]">
+            <button
+              onClick={copyCode}
+              className="absolute top-2 right-2 z-10 px-3 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded transition-colors"
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+            <div
+              className="h-full overflow-auto [&>pre]:min-h-full [&>pre]:m-0 [&>pre]:p-4 [&>pre]:text-sm"
+              dangerouslySetInnerHTML={{ __html: codeHtml }}
+            />
+          </Tabs.Content>
+        </div>
+      </Tabs.Root>
+    </div>
+  );
+}

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -40,13 +40,14 @@
         class="flex items-center flex-wrap justify-center gap-4 md:gap-0 md:space-x-4 order-2 md:order-3"
       >
         <a href="/components/background" class="text-sm font-medium"> Components </a>
+        <a href="/blocks" class="text-sm font-medium"> Blocks </a>
         <a
           href="http://samples.jsx.email"
           target="_blank"
           rel="noreferrer"
           class="text-sm font-medium flex items-center"
         >
-          Email Samples
+          Samples
           <svg
             class="inline-block ml-1 w-3 h-3"
             viewBox="0 0 12 12"

--- a/apps/web/src/components/Header.astro
+++ b/apps/web/src/components/Header.astro
@@ -36,12 +36,18 @@
         Components
       </a>
       <a
+        href="/blocks"
+        class="text-sm font-medium hover:text-gray-600 dark:hover:text-gray-300"
+      >
+        Blocks
+      </a>
+      <a
         href="http://samples.jsx.email"
         target="_blank"
         rel="noreferrer"
         class="text-sm font-medium hover:text-gray-600 dark:hover:text-gray-300"
       >
-        Email Samples
+        Samples
         <svg
           class="inline-block ml-1 w-3 h-3"
           viewBox="0 0 12 12"
@@ -219,10 +225,18 @@
         Components
       </a>
       <a
-        href="/email-samples"
+        href="/blocks"
         class="block text-base font-medium hover:text-gray-600 dark:hover:text-gray-300 py-2"
       >
-        Email Samples
+        Blocks
+      </a>
+      <a
+        href="http://samples.jsx.email"
+        target="_blank"
+        rel="noreferrer"
+        class="block text-base font-medium hover:text-gray-600 dark:hover:text-gray-300 py-2"
+      >
+        Samples
         <svg
           class="inline-block ml-1 w-3 h-3"
           viewBox="0 0 12 12"

--- a/apps/web/src/components/PatternCard.astro
+++ b/apps/web/src/components/PatternCard.astro
@@ -1,0 +1,102 @@
+---
+interface Props {
+  name: string;
+  renderedHtml: string;
+  code: string;
+  id: string;
+}
+
+const { name, renderedHtml, code, id } = Astro.props;
+---
+
+<div class="pattern-card border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden mb-8 bg-white dark:bg-gray-900">
+  <!-- Header with title and tabs -->
+  <div class="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-2">
+    <h3 class="font-semibold text-gray-800 dark:text-gray-200 text-sm">{name}</h3>
+
+    <div class="tabs flex gap-1 bg-gray-200 dark:bg-gray-700 rounded-md p-1">
+      <button
+        class="tab-btn px-3 py-1 text-xs font-medium rounded transition-colors text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white data-[active=true]:bg-white dark:data-[active=true]:bg-gray-600 data-[active=true]:text-gray-900 dark:data-[active=true]:text-white"
+        data-tab="preview"
+        data-target={`${id}-preview`}
+        data-active="true"
+      >
+        Preview
+      </button>
+      <button
+        class="tab-btn px-3 py-1 text-xs font-medium rounded transition-colors text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white data-[active=true]:bg-white dark:data-[active=true]:bg-gray-600 data-[active=true]:text-gray-900 dark:data-[active=true]:text-white"
+        data-tab="code"
+        data-target={`${id}-code`}
+        data-active="false"
+      >
+        Code
+      </button>
+    </div>
+  </div>
+
+  <!-- Preview Panel -->
+  <div id={`${id}-preview`} class="tab-panel p-6 bg-white dark:bg-gray-900" data-visible="true">
+    <iframe
+      srcDoc={`<!DOCTYPE html><html><head><style>body{margin:0;padding:16px;font-family:system-ui,sans-serif;background:#fff;}</style></head><body>${renderedHtml}</body></html>`}
+      class="border-0 w-full bg-white rounded"
+      style="min-height: 80px; max-height: 300px;"
+      title={`Preview: ${name}`}
+    ></iframe>
+  </div>
+
+  <!-- Code Panel -->
+  <div id={`${id}-code`} class="tab-panel hidden relative" data-visible="false">
+    <button
+      class="copy-btn absolute top-2 right-2 z-10 px-3 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded transition-colors"
+      data-code={code}
+    >
+      Copy
+    </button>
+    <pre class="p-4 bg-gray-900 text-gray-100 text-sm overflow-auto max-h-[400px] m-0"><code>{code}</code></pre>
+  </div>
+</div>
+
+<style>
+  .tab-panel[data-visible="false"] {
+    display: none;
+  }
+  .tab-panel[data-visible="true"] {
+    display: block;
+  }
+</style>
+
+<script>
+  // Tab switching
+  document.querySelectorAll('.pattern-card').forEach((card) => {
+    const buttons = card.querySelectorAll('.tab-btn');
+    const panels = card.querySelectorAll('.tab-panel');
+
+    buttons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const targetId = (btn as HTMLElement).dataset.target;
+
+        // Update button states
+        buttons.forEach((b) => (b as HTMLElement).dataset.active = 'false');
+        (btn as HTMLElement).dataset.active = 'true';
+
+        // Update panel visibility
+        panels.forEach((panel) => {
+          (panel as HTMLElement).dataset.visible = panel.id === targetId ? 'true' : 'false';
+        });
+      });
+    });
+  });
+
+  // Copy functionality
+  document.querySelectorAll('.copy-btn').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const code = (btn as HTMLElement).dataset.code;
+      if (code) {
+        await navigator.clipboard.writeText(code);
+        const originalText = btn.textContent;
+        btn.textContent = 'Copied!';
+        setTimeout(() => (btn.textContent = originalText), 2000);
+      }
+    });
+  });
+</script>

--- a/apps/web/src/components/PatternCard.astro
+++ b/apps/web/src/components/PatternCard.astro
@@ -9,9 +9,13 @@ interface Props {
 const { name, renderedHtml, code, id } = Astro.props;
 ---
 
-<div class="pattern-card border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden mb-8 bg-white dark:bg-gray-900">
+<div
+  class="pattern-card border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden mb-8 bg-white dark:bg-gray-900"
+>
   <!-- Header with title and tabs -->
-  <div class="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-2">
+  <div
+    class="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-2"
+  >
     <h3 class="font-semibold text-gray-800 dark:text-gray-200 text-sm">{name}</h3>
 
     <div class="tabs flex gap-1 bg-gray-200 dark:bg-gray-700 rounded-md p-1">
@@ -37,11 +41,10 @@ const { name, renderedHtml, code, id } = Astro.props;
   <!-- Preview Panel -->
   <div id={`${id}-preview`} class="tab-panel p-6 bg-white dark:bg-gray-900" data-visible="true">
     <iframe
-      srcDoc={`<!DOCTYPE html><html><head><style>body{margin:0;padding:16px;font-family:system-ui,sans-serif;background:#fff;}</style></head><body>${renderedHtml}</body></html>`}
+      srcdoc={`<!DOCTYPE html><html><head><style>body{margin:0;padding:16px;font-family:system-ui,sans-serif;background:#fff;}</style></head><body>${renderedHtml}</body></html>`}
       class="border-0 w-full bg-white rounded"
       style="min-height: 80px; max-height: 300px;"
-      title={`Preview: ${name}`}
-    ></iframe>
+      title={`Preview: ${name}`}></iframe>
   </div>
 
   <!-- Code Panel -->
@@ -52,15 +55,16 @@ const { name, renderedHtml, code, id } = Astro.props;
     >
       Copy
     </button>
-    <pre class="p-4 bg-gray-900 text-gray-100 text-sm overflow-auto max-h-[400px] m-0"><code>{code}</code></pre>
+    <pre
+      class="p-4 bg-gray-900 text-gray-100 text-sm overflow-auto max-h-[400px] m-0"><code>{code}</code></pre>
   </div>
 </div>
 
 <style>
-  .tab-panel[data-visible="false"] {
+  .tab-panel[data-visible='false'] {
     display: none;
   }
-  .tab-panel[data-visible="true"] {
+  .tab-panel[data-visible='true'] {
     display: block;
   }
 </style>
@@ -76,7 +80,7 @@ const { name, renderedHtml, code, id } = Astro.props;
         const targetId = (btn as HTMLElement).dataset.target;
 
         // Update button states
-        buttons.forEach((b) => (b as HTMLElement).dataset.active = 'false');
+        buttons.forEach((b) => ((b as HTMLElement).dataset.active = 'false'));
         (btn as HTMLElement).dataset.active = 'true';
 
         // Update panel visibility

--- a/apps/web/src/content/docs/contributing.md
+++ b/apps/web/src/content/docs/contributing.md
@@ -1,0 +1,6 @@
+---
+title: 'Contributing'
+description: 'We 💛 contributions!'
+---
+
+<!--@include: @/include/CONTRIBUTING.md-->

--- a/apps/web/src/pages/blocks/articles.astro
+++ b/apps/web/src/pages/blocks/articles.astro
@@ -1,0 +1,41 @@
+---
+import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { BlockPreview } from '../../components/BlockPreview';
+import { getRenderedBlocks, type Block } from '../../blocks/articles';
+
+const renderedBlocks: Block[] = await getRenderedBlocks();
+---
+
+<Layout title="Articles - Blocks - JSX Email">
+  <Header />
+  <main class="min-h-screen">
+    <div class="container-custom mx-auto px-4 md:px-6 py-16 pt-24">
+      <div class="mb-8">
+        <a href="/blocks" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-sm mb-4 inline-block">&larr; Back to Blocks</a>
+        <h1 class="text-4xl font-bold mb-4">Articles</h1>
+        <p class="text-lg text-gray-600 dark:text-gray-400">
+          Display blog posts, news articles, and content previews.
+        </p>
+      </div>
+
+      <section class="mb-16">
+        {
+          renderedBlocks.map((block) => (
+            <BlockPreview
+              client:load
+              name={block.name}
+              renderedHtml={block.renderedHtml}
+              code={block.code}
+              codeHtml={block.codeHtml}
+              height={450}
+            />
+          ))
+        }
+      </section>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/apps/web/src/pages/blocks/avatars.astro
+++ b/apps/web/src/pages/blocks/avatars.astro
@@ -1,0 +1,42 @@
+---
+import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { BlockPreview } from '../../components/BlockPreview';
+import { getRenderedBlocks, type Block } from '../../blocks/avatars';
+
+// Get all rendered blocks at build time
+const renderedBlocks: Block[] = await getRenderedBlocks();
+---
+
+<Layout title="User Avatars - Blocks - JSX Email">
+  <Header />
+  <main class="min-h-screen">
+    <div class="container-custom mx-auto px-4 md:px-6 py-16 pt-24">
+      <div class="mb-8">
+        <a href="/blocks" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-sm mb-4 inline-block">&larr; Back to Blocks</a>
+        <h1 class="text-4xl font-bold mb-4">User Avatars</h1>
+        <p class="text-lg text-gray-600 dark:text-gray-400">
+          Display user profile images in your email templates.
+        </p>
+      </div>
+
+      <section class="mb-16">
+        {
+          renderedBlocks.map((block) => (
+            <BlockPreview
+              client:load
+              name={block.name}
+              renderedHtml={block.renderedHtml}
+              code={block.code}
+              codeHtml={block.codeHtml}
+              height={300}
+            />
+          ))
+        }
+      </section>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/apps/web/src/pages/blocks/ecommerce-pricing.astro
+++ b/apps/web/src/pages/blocks/ecommerce-pricing.astro
@@ -1,0 +1,41 @@
+---
+import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { BlockPreview } from '../../components/BlockPreview';
+import { getRenderedBlocks, type Block } from '../../blocks/ecommerce-pricing';
+
+const renderedBlocks: Block[] = await getRenderedBlocks();
+---
+
+<Layout title="Ecommerce Pricing - Blocks - JSX Email">
+  <Header />
+  <main class="min-h-screen">
+    <div class="container-custom mx-auto px-4 md:px-6 py-16 pt-24">
+      <div class="mb-8">
+        <a href="/blocks" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-sm mb-4 inline-block">&larr; Back to Blocks</a>
+        <h1 class="text-4xl font-bold mb-4">Ecommerce Pricing</h1>
+        <p class="text-lg text-gray-600 dark:text-gray-400">
+          Display prices, discounts, and pricing tables in your transactional emails.
+        </p>
+      </div>
+
+      <section class="mb-16">
+        {
+          renderedBlocks.map((block) => (
+            <BlockPreview
+              client:load
+              name={block.name}
+              renderedHtml={block.renderedHtml}
+              code={block.code}
+              codeHtml={block.codeHtml}
+              height={300}
+            />
+          ))
+        }
+      </section>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/apps/web/src/pages/blocks/feedback.astro
+++ b/apps/web/src/pages/blocks/feedback.astro
@@ -1,0 +1,41 @@
+---
+import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { BlockPreview } from '../../components/BlockPreview';
+import { getRenderedBlocks, type Block } from '../../blocks/feedback';
+
+const renderedBlocks: Block[] = await getRenderedBlocks();
+---
+
+<Layout title="Feedback - Blocks - JSX Email">
+  <Header />
+  <main class="min-h-screen">
+    <div class="container-custom mx-auto px-4 md:px-6 py-16 pt-24">
+      <div class="mb-8">
+        <a href="/blocks" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-sm mb-4 inline-block">&larr; Back to Blocks</a>
+        <h1 class="text-4xl font-bold mb-4">Feedback</h1>
+        <p class="text-lg text-gray-600 dark:text-gray-400">
+          Collect user feedback with star ratings and emoji reactions.
+        </p>
+      </div>
+
+      <section class="mb-16">
+        {
+          renderedBlocks.map((block) => (
+            <BlockPreview
+              client:load
+              name={block.name}
+              renderedHtml={block.renderedHtml}
+              code={block.code}
+              codeHtml={block.codeHtml}
+              height={250}
+            />
+          ))
+        }
+      </section>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/apps/web/src/pages/blocks/gallery.astro
+++ b/apps/web/src/pages/blocks/gallery.astro
@@ -1,0 +1,41 @@
+---
+import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { BlockPreview } from '../../components/BlockPreview';
+import { getRenderedBlocks, type Block } from '../../blocks/gallery';
+
+const renderedBlocks: Block[] = await getRenderedBlocks();
+---
+
+<Layout title="Gallery - Blocks - JSX Email">
+  <Header />
+  <main class="min-h-screen">
+    <div class="container-custom mx-auto px-4 md:px-6 py-16 pt-24">
+      <div class="mb-8">
+        <a href="/blocks" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-sm mb-4 inline-block">&larr; Back to Blocks</a>
+        <h1 class="text-4xl font-bold mb-4">Gallery</h1>
+        <p class="text-lg text-gray-600 dark:text-gray-400">
+          Display images in single, multi-column, and grid layouts.
+        </p>
+      </div>
+
+      <section class="mb-16">
+        {
+          renderedBlocks.map((block) => (
+            <BlockPreview
+              client:load
+              name={block.name}
+              renderedHtml={block.renderedHtml}
+              code={block.code}
+              codeHtml={block.codeHtml}
+              height={350}
+            />
+          ))
+        }
+      </section>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/apps/web/src/pages/blocks/index.astro
+++ b/apps/web/src/pages/blocks/index.astro
@@ -1,0 +1,174 @@
+---
+import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+
+interface Block {
+  name: string;
+  slug: string;
+  blockCount: number;
+  icon: string;
+}
+
+interface CategoryGroup {
+  name: string;
+  blocks: Block[];
+}
+
+const categoryGroups: CategoryGroup[] = [
+  {
+    name: 'General',
+    blocks: [
+      { name: 'Avatars', slug: 'avatars', blockCount: 4, icon: 'avatars' },
+    ]
+  },
+  {
+    name: 'Marketing',
+    blocks: [
+      { name: 'Marketing', slug: 'marketing', blockCount: 3, icon: 'marketing' },
+      { name: 'Ecommerce Pricing', slug: 'ecommerce-pricing', blockCount: 2, icon: 'pricing' },
+      { name: 'Features', slug: 'features', blockCount: 3, icon: 'features' },
+    ]
+  },
+  {
+    name: 'User Feedback',
+    blocks: [
+      { name: 'Feedback', slug: 'feedback', blockCount: 2, icon: 'feedback' },
+      { name: 'Stats', slug: 'stats', blockCount: 2, icon: 'stats' },
+      { name: 'Testimonials', slug: 'testimonials', blockCount: 3, icon: 'testimonials' },
+    ]
+  },
+  {
+    name: 'Layout',
+    blocks: [
+      { name: 'Gallery', slug: 'gallery', blockCount: 4, icon: 'gallery' },
+      { name: 'Articles', slug: 'articles', blockCount: 2, icon: 'articles' },
+    ]
+  },
+];
+---
+
+<Layout title="Blocks - JSX Email">
+  <Header />
+  <main class="min-h-screen">
+    <div class="container-custom mx-auto px-4 md:px-6 py-16 pt-24">
+      <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">Blocks</h1>
+        <p class="text-gray-600 dark:text-gray-400">
+          Ready-to-use email blocks you can copy and paste into your templates.
+        </p>
+      </div>
+
+      <div class="border-t border-gray-200 dark:border-gray-800 pt-8">
+        {categoryGroups.map((group) => (
+          <section class="mb-12">
+            <h2 class="text-lg font-medium mb-4 text-gray-500 dark:text-gray-400">{group.name}</h2>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {group.blocks.map((block) => (
+                <a
+                  href={`/blocks/${block.slug}`}
+                  class="group block bg-white dark:bg-black border border-gray-200 dark:border-gray-800 rounded-2xl overflow-hidden hover:border-gray-400 dark:hover:border-gray-600 transition-colors"
+                >
+                  <div class="aspect-[4/3] bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-8">
+                    <div class="block-icon" data-icon={block.icon}>
+                      {block.icon === 'avatars' && (
+                        <div class="flex -space-x-2">
+                          <div class="w-8 h-8 rounded-full bg-gray-500"></div>
+                          <div class="w-8 h-8 rounded-full bg-gray-400"></div>
+                          <div class="w-8 h-8 rounded-full bg-gray-300"></div>
+                        </div>
+                      )}
+                      {block.icon === 'marketing' && (
+                        <div class="flex flex-col items-center gap-2">
+                          <svg class="w-8 h-8 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"></path>
+                          </svg>
+                        </div>
+                      )}
+                      {block.icon === 'pricing' && (
+                        <div class="flex items-center gap-1">
+                          <div class="text-2xl font-bold text-gray-400 dark:text-gray-500">$</div>
+                          <div class="flex flex-col gap-1">
+                            <div class="w-8 h-1.5 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                            <div class="w-6 h-1 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                          </div>
+                        </div>
+                      )}
+                      {block.icon === 'features' && (
+                        <div class="flex flex-col gap-2">
+                          <div class="flex items-center gap-2">
+                            <div class="w-4 h-4 border border-gray-400 dark:border-gray-500 rounded flex items-center justify-center">
+                              <div class="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-sm"></div>
+                            </div>
+                            <div class="w-12 h-1.5 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                          </div>
+                          <div class="flex items-center gap-2">
+                            <div class="w-4 h-4 border border-gray-400 dark:border-gray-500 rounded flex items-center justify-center">
+                              <div class="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-sm"></div>
+                            </div>
+                            <div class="w-10 h-1.5 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                          </div>
+                        </div>
+                      )}
+                      {block.icon === 'feedback' && (
+                        <div class="relative">
+                          <div class="w-12 h-10 bg-gray-200 dark:bg-gray-700 rounded-lg"></div>
+                          <div class="absolute -bottom-1 left-2 w-3 h-3 bg-gray-200 dark:bg-gray-700 rotate-45"></div>
+                        </div>
+                      )}
+                      {block.icon === 'stats' && (
+                        <div class="flex items-end gap-1">
+                          <div class="w-4 h-6 bg-gray-300 dark:bg-gray-600 rounded-t"></div>
+                          <div class="w-4 h-10 bg-gray-400 dark:bg-gray-500 rounded-t"></div>
+                          <div class="w-4 h-8 bg-gray-300 dark:bg-gray-600 rounded-t"></div>
+                          <div class="w-4 h-12 bg-gray-400 dark:bg-gray-500 rounded-t"></div>
+                        </div>
+                      )}
+                      {block.icon === 'testimonials' && (
+                        <div class="flex flex-col items-center gap-2">
+                          <div class="text-2xl text-gray-400 dark:text-gray-500">"</div>
+                          <div class="flex flex-col gap-1">
+                            <div class="w-16 h-1 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                            <div class="w-12 h-1 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                          </div>
+                        </div>
+                      )}
+                      {block.icon === 'gallery' && (
+                        <div class="grid grid-cols-2 gap-1">
+                          <div class="w-6 h-6 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                          <div class="w-6 h-6 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                          <div class="w-6 h-6 bg-gray-200 dark:bg-gray-700 rounded flex items-center justify-center">
+                            <svg class="w-3 h-3 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                            </svg>
+                          </div>
+                          <div class="w-6 h-6 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                        </div>
+                      )}
+                      {block.icon === 'articles' && (
+                        <div class="flex gap-2">
+                          <div class="w-8 h-10 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                          <div class="flex flex-col gap-1">
+                            <div class="w-12 h-1.5 bg-gray-400 dark:bg-gray-500 rounded"></div>
+                            <div class="w-10 h-1 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                            <div class="w-8 h-1 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                  <div class="p-4">
+                    <h3 class="font-medium">{block.name}</h3>
+                    <p class="text-gray-500 dark:text-gray-400 text-sm">{block.blockCount} block{block.blockCount !== 1 ? 's' : ''}</p>
+                  </div>
+                </a>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/apps/web/src/pages/blocks/index.astro
+++ b/apps/web/src/pages/blocks/index.astro
@@ -18,34 +18,31 @@ interface CategoryGroup {
 
 const categoryGroups: CategoryGroup[] = [
   {
-    name: 'General',
+    name: 'Layout',
     blocks: [
-      { name: 'Avatars', slug: 'avatars', blockCount: 4, icon: 'avatars' },
+      { name: 'Gallery', slug: 'gallery', blockCount: 4, icon: 'gallery' },
+      { name: 'Articles', slug: 'articles', blockCount: 2, icon: 'articles' }
+    ]
+  },
+  {
+    name: 'User Feedback',
+    blocks: [
+      { name: 'Surveys', slug: 'surveys', blockCount: 3, icon: 'surveys' },
+      { name: 'Feedback', slug: 'feedback', blockCount: 2, icon: 'feedback' },
+      { name: 'Testimonials', slug: 'testimonials', blockCount: 2, icon: 'testimonials' }
     ]
   },
   {
     name: 'Marketing',
     blocks: [
       { name: 'Marketing', slug: 'marketing', blockCount: 3, icon: 'marketing' },
-      { name: 'Ecommerce Pricing', slug: 'ecommerce-pricing', blockCount: 2, icon: 'pricing' },
-      { name: 'Features', slug: 'features', blockCount: 3, icon: 'features' },
+      { name: 'Ecommerce Pricing', slug: 'ecommerce-pricing', blockCount: 2, icon: 'pricing' }
     ]
   },
   {
-    name: 'User Feedback',
-    blocks: [
-      { name: 'Feedback', slug: 'feedback', blockCount: 2, icon: 'feedback' },
-      { name: 'Stats', slug: 'stats', blockCount: 2, icon: 'stats' },
-      { name: 'Testimonials', slug: 'testimonials', blockCount: 3, icon: 'testimonials' },
-    ]
-  },
-  {
-    name: 'Layout',
-    blocks: [
-      { name: 'Gallery', slug: 'gallery', blockCount: 4, icon: 'gallery' },
-      { name: 'Articles', slug: 'articles', blockCount: 2, icon: 'articles' },
-    ]
-  },
+    name: 'General',
+    blocks: [{ name: 'Avatars', slug: 'avatars', blockCount: 4, icon: 'avatars' }]
+  }
 ];
 ---
 
@@ -61,112 +58,135 @@ const categoryGroups: CategoryGroup[] = [
       </div>
 
       <div class="border-t border-gray-200 dark:border-gray-800 pt-8">
-        {categoryGroups.map((group) => (
-          <section class="mb-12">
-            <h2 class="text-lg font-medium mb-4 text-gray-500 dark:text-gray-400">{group.name}</h2>
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-              {group.blocks.map((block) => (
-                <a
-                  href={`/blocks/${block.slug}`}
-                  class="group block bg-white dark:bg-black border border-gray-200 dark:border-gray-800 rounded-2xl overflow-hidden hover:border-gray-400 dark:hover:border-gray-600 transition-colors"
-                >
-                  <div class="aspect-[4/3] bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-8">
-                    <div class="block-icon" data-icon={block.icon}>
-                      {block.icon === 'avatars' && (
-                        <div class="flex -space-x-2">
-                          <div class="w-8 h-8 rounded-full bg-gray-500"></div>
-                          <div class="w-8 h-8 rounded-full bg-gray-400"></div>
-                          <div class="w-8 h-8 rounded-full bg-gray-300"></div>
-                        </div>
-                      )}
-                      {block.icon === 'marketing' && (
-                        <div class="flex flex-col items-center gap-2">
-                          <svg class="w-8 h-8 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"></path>
-                          </svg>
-                        </div>
-                      )}
-                      {block.icon === 'pricing' && (
-                        <div class="flex items-center gap-1">
-                          <div class="text-2xl font-bold text-gray-400 dark:text-gray-500">$</div>
-                          <div class="flex flex-col gap-1">
-                            <div class="w-8 h-1.5 bg-gray-300 dark:bg-gray-600 rounded"></div>
-                            <div class="w-6 h-1 bg-gray-300 dark:bg-gray-600 rounded"></div>
+        {
+          categoryGroups.map((group) => (
+            <section class="mb-12">
+              <h2 class="text-lg font-medium mb-4 text-gray-500 dark:text-gray-400">
+                {group.name}
+              </h2>
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {group.blocks.map((block) => (
+                  <a
+                    href={`/blocks/${block.slug}`}
+                    class="group block bg-white dark:bg-black border border-gray-200 dark:border-gray-800 rounded-2xl overflow-hidden hover:border-gray-400 dark:hover:border-gray-600 transition-colors"
+                  >
+                    <div class="aspect-[4/3] bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-8">
+                      <div class="block-icon" data-icon={block.icon}>
+                        {block.icon === 'avatars' && (
+                          <div class="flex -space-x-2">
+                            <div class="w-8 h-8 rounded-full bg-gray-500" />
+                            <div class="w-8 h-8 rounded-full bg-gray-400" />
+                            <div class="w-8 h-8 rounded-full bg-gray-300" />
                           </div>
-                        </div>
-                      )}
-                      {block.icon === 'features' && (
-                        <div class="flex flex-col gap-2">
-                          <div class="flex items-center gap-2">
-                            <div class="w-4 h-4 border border-gray-400 dark:border-gray-500 rounded flex items-center justify-center">
-                              <div class="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-sm"></div>
-                            </div>
-                            <div class="w-12 h-1.5 bg-gray-300 dark:bg-gray-600 rounded"></div>
-                          </div>
-                          <div class="flex items-center gap-2">
-                            <div class="w-4 h-4 border border-gray-400 dark:border-gray-500 rounded flex items-center justify-center">
-                              <div class="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-sm"></div>
-                            </div>
-                            <div class="w-10 h-1.5 bg-gray-300 dark:bg-gray-600 rounded"></div>
-                          </div>
-                        </div>
-                      )}
-                      {block.icon === 'feedback' && (
-                        <div class="relative">
-                          <div class="w-12 h-10 bg-gray-200 dark:bg-gray-700 rounded-lg"></div>
-                          <div class="absolute -bottom-1 left-2 w-3 h-3 bg-gray-200 dark:bg-gray-700 rotate-45"></div>
-                        </div>
-                      )}
-                      {block.icon === 'stats' && (
-                        <div class="flex items-end gap-1">
-                          <div class="w-4 h-6 bg-gray-300 dark:bg-gray-600 rounded-t"></div>
-                          <div class="w-4 h-10 bg-gray-400 dark:bg-gray-500 rounded-t"></div>
-                          <div class="w-4 h-8 bg-gray-300 dark:bg-gray-600 rounded-t"></div>
-                          <div class="w-4 h-12 bg-gray-400 dark:bg-gray-500 rounded-t"></div>
-                        </div>
-                      )}
-                      {block.icon === 'testimonials' && (
-                        <div class="flex flex-col items-center gap-2">
-                          <div class="text-2xl text-gray-400 dark:text-gray-500">"</div>
-                          <div class="flex flex-col gap-1">
-                            <div class="w-16 h-1 bg-gray-300 dark:bg-gray-600 rounded"></div>
-                            <div class="w-12 h-1 bg-gray-300 dark:bg-gray-600 rounded"></div>
-                          </div>
-                        </div>
-                      )}
-                      {block.icon === 'gallery' && (
-                        <div class="grid grid-cols-2 gap-1">
-                          <div class="w-6 h-6 bg-gray-200 dark:bg-gray-700 rounded"></div>
-                          <div class="w-6 h-6 bg-gray-300 dark:bg-gray-600 rounded"></div>
-                          <div class="w-6 h-6 bg-gray-200 dark:bg-gray-700 rounded flex items-center justify-center">
-                            <svg class="w-3 h-3 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                        )}
+                        {block.icon === 'marketing' && (
+                          <div class="flex flex-col items-center gap-2">
+                            <svg
+                              class="w-8 h-8 text-gray-400 dark:text-gray-500"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="1.5"
+                                d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"
+                              />
                             </svg>
                           </div>
-                          <div class="w-6 h-6 bg-gray-300 dark:bg-gray-600 rounded"></div>
-                        </div>
-                      )}
-                      {block.icon === 'articles' && (
-                        <div class="flex gap-2">
-                          <div class="w-8 h-10 bg-gray-200 dark:bg-gray-700 rounded"></div>
-                          <div class="flex flex-col gap-1">
-                            <div class="w-12 h-1.5 bg-gray-400 dark:bg-gray-500 rounded"></div>
-                            <div class="w-10 h-1 bg-gray-300 dark:bg-gray-600 rounded"></div>
-                            <div class="w-8 h-1 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                        )}
+                        {block.icon === 'pricing' && (
+                          <div class="flex items-center gap-1">
+                            <div class="text-2xl font-bold text-gray-400 dark:text-gray-500">$</div>
+                            <div class="flex flex-col gap-1">
+                              <div class="w-8 h-1.5 bg-gray-300 dark:bg-gray-600 rounded" />
+                              <div class="w-6 h-1 bg-gray-300 dark:bg-gray-600 rounded" />
+                            </div>
                           </div>
-                        </div>
-                      )}
+                        )}
+                        {block.icon === 'surveys' && (
+                          <div class="flex gap-1">
+                            <div class="w-7 h-7 rounded-md bg-gray-500 flex items-center justify-center text-white text-xs font-medium">
+                              1
+                            </div>
+                            <div class="w-7 h-7 rounded-md bg-gray-500 flex items-center justify-center text-white text-xs font-medium">
+                              2
+                            </div>
+                            <div class="w-7 h-7 rounded-md bg-gray-500 flex items-center justify-center text-white text-xs font-medium">
+                              3
+                            </div>
+                            <div class="w-7 h-7 rounded-md bg-gray-400 flex items-center justify-center text-white text-xs font-medium">
+                              4
+                            </div>
+                            <div class="w-7 h-7 rounded-md bg-gray-400 flex items-center justify-center text-white text-xs font-medium">
+                              5
+                            </div>
+                          </div>
+                        )}
+                        {block.icon === 'feedback' && (
+                          <div class="flex gap-2">
+                            <div class="w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-lg">
+                              😊
+                            </div>
+                            <div class="w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-lg">
+                              😐
+                            </div>
+                            <div class="w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-lg">
+                              😞
+                            </div>
+                          </div>
+                        )}
+                        {block.icon === 'testimonials' && (
+                          <div class="flex flex-col items-center gap-2">
+                            <div class="text-2xl text-gray-400 dark:text-gray-500">"</div>
+                            <div class="flex flex-col gap-1">
+                              <div class="w-16 h-1 bg-gray-300 dark:bg-gray-600 rounded" />
+                              <div class="w-12 h-1 bg-gray-300 dark:bg-gray-600 rounded" />
+                            </div>
+                          </div>
+                        )}
+                        {block.icon === 'gallery' && (
+                          <div class="grid grid-cols-2 gap-1">
+                            <div class="w-6 h-6 bg-gray-200 dark:bg-gray-700 rounded" />
+                            <div class="w-6 h-6 bg-gray-300 dark:bg-gray-600 rounded" />
+                            <div class="w-6 h-6 bg-gray-200 dark:bg-gray-700 rounded flex items-center justify-center">
+                              <svg
+                                class="w-3 h-3 text-gray-400 dark:text-gray-500"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                              </svg>
+                            </div>
+                            <div class="w-6 h-6 bg-gray-300 dark:bg-gray-600 rounded" />
+                          </div>
+                        )}
+                        {block.icon === 'articles' && (
+                          <div class="flex gap-2">
+                            <div class="w-8 h-10 bg-gray-200 dark:bg-gray-700 rounded" />
+                            <div class="flex flex-col gap-1">
+                              <div class="w-12 h-1.5 bg-gray-400 dark:bg-gray-500 rounded" />
+                              <div class="w-10 h-1 bg-gray-300 dark:bg-gray-600 rounded" />
+                              <div class="w-8 h-1 bg-gray-300 dark:bg-gray-600 rounded" />
+                            </div>
+                          </div>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                  <div class="p-4">
-                    <h3 class="font-medium">{block.name}</h3>
-                    <p class="text-gray-500 dark:text-gray-400 text-sm">{block.blockCount} block{block.blockCount !== 1 ? 's' : ''}</p>
-                  </div>
-                </a>
-              ))}
-            </div>
-          </section>
-        ))}
+                    <div class="p-4">
+                      <h3 class="font-medium">{block.name}</h3>
+                      <p class="text-gray-500 dark:text-gray-400 text-sm">
+                        {block.blockCount} block{block.blockCount !== 1 ? 's' : ''}
+                      </p>
+                    </div>
+                  </a>
+                ))}
+              </div>
+            </section>
+          ))
+        }
       </div>
     </div>
   </main>

--- a/apps/web/src/pages/blocks/marketing.astro
+++ b/apps/web/src/pages/blocks/marketing.astro
@@ -1,0 +1,41 @@
+---
+import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { BlockPreview } from '../../components/BlockPreview';
+import { getRenderedBlocks, type Block } from '../../blocks/marketing';
+
+const renderedBlocks: Block[] = await getRenderedBlocks();
+---
+
+<Layout title="Marketing - Blocks - JSX Email">
+  <Header />
+  <main class="min-h-screen">
+    <div class="container-custom mx-auto px-4 md:px-6 py-16 pt-24">
+      <div class="mb-8">
+        <a href="/blocks" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-sm mb-4 inline-block">&larr; Back to Blocks</a>
+        <h1 class="text-4xl font-bold mb-4">Marketing</h1>
+        <p class="text-lg text-gray-600 dark:text-gray-400">
+          Hero sections, announcements, and promotional blocks for your email campaigns.
+        </p>
+      </div>
+
+      <section class="mb-16">
+        {
+          renderedBlocks.map((block) => (
+            <BlockPreview
+              client:load
+              name={block.name}
+              renderedHtml={block.renderedHtml}
+              code={block.code}
+              codeHtml={block.codeHtml}
+              height={300}
+            />
+          ))
+        }
+      </section>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/apps/web/src/pages/blocks/surveys.astro
+++ b/apps/web/src/pages/blocks/surveys.astro
@@ -1,0 +1,44 @@
+---
+import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { BlockPreview } from '../../components/BlockPreview';
+import { getRenderedBlocks, type Block } from '../../blocks/surveys';
+
+const renderedBlocks: Block[] = await getRenderedBlocks();
+---
+
+<Layout title="Surveys - Blocks - JSX Email">
+  <Header />
+  <main class="min-h-screen">
+    <div class="container-custom mx-auto px-4 md:px-6 py-16 pt-24">
+      <div class="mb-8">
+        <a href="/blocks" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-sm mb-4 inline-block">&larr; Back to Blocks</a>
+        <h1 class="text-4xl font-bold mb-4">Surveys</h1>
+        <p class="text-lg text-gray-600 dark:text-gray-400">
+          Collect feedback with rating scales, satisfaction surveys, and review displays.
+        </p>
+      </div>
+
+      <section class="mb-16">
+        {
+          renderedBlocks.map((block) => {
+            const height = block.name === 'Survey Section' ? 300 : 400;
+            return (
+              <BlockPreview
+                client:load
+                name={block.name}
+                renderedHtml={block.renderedHtml}
+                code={block.code}
+                codeHtml={block.codeHtml}
+                height={height}
+              />
+            );
+          })
+        }
+      </section>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/apps/web/src/pages/blocks/testimonials.astro
+++ b/apps/web/src/pages/blocks/testimonials.astro
@@ -1,0 +1,44 @@
+---
+import '../../styles/global.css';
+import Layout from '../../components/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { BlockPreview } from '../../components/BlockPreview';
+import { getRenderedBlocks, type Block } from '../../blocks/testimonials';
+
+const renderedBlocks: Block[] = await getRenderedBlocks();
+---
+
+<Layout title="Testimonials - Blocks - JSX Email">
+  <Header />
+  <main class="min-h-screen">
+    <div class="container-custom mx-auto px-4 md:px-6 py-16 pt-24">
+      <div class="mb-8">
+        <a href="/blocks" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-sm mb-4 inline-block">&larr; Back to Blocks</a>
+        <h1 class="text-4xl font-bold mb-4">Testimonials</h1>
+        <p class="text-lg text-gray-600 dark:text-gray-400">
+          Showcase customer reviews and testimonials in your emails.
+        </p>
+      </div>
+
+      <section class="mb-16">
+        {
+          renderedBlocks.map((block) => {
+            const height = block.name === 'Testimonial with large avatar' ? 400 : 300;
+            return (
+              <BlockPreview
+                client:load
+                name={block.name}
+                renderedHtml={block.renderedHtml}
+                code={block.code}
+                codeHtml={block.codeHtml}
+                height={height}
+              />
+            );
+          })
+        }
+      </section>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.32.2
         version: 0.32.6(astro@5.7.10(@types/node@25.0.8)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.55.1)(tsx@4.19.2)(typescript@5.9.3)(yaml@2.8.2))
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.2
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
         specifier: 19.2.8
         version: 19.2.8
@@ -203,6 +206,9 @@ importers:
       css-fade:
         specifier: ^1.0.7
         version: 1.0.9
+      jsx-email:
+        specifier: workspace:*
+        version: link:../../packages/jsx-email
       motion:
         specifier: ^12.5.0
         version: 12.9.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -215,6 +221,9 @@ importers:
       sharp:
         specifier: ^0.32.5
         version: 0.32.6
+      shiki:
+        specifier: ^3.7.0
+        version: 3.7.0
     devDependencies:
       '@astrojs/tailwind':
         specifier: ^6.0.0
@@ -1732,6 +1741,9 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
   '@radix-ui/react-arrow@1.1.3':
     resolution: {integrity: sha512-2dvVU4jva0qkNZH6HHWuSz5FN5GeU5tymvCgutF8WaXz9WnD1NgUhy73cqzkjkN4Zkn8lfTPv5JIfrC221W+Nw==}
     peerDependencies:
@@ -2068,6 +2080,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.0.3':
     resolution: {integrity: sha512-Pf/t/GkndH7CQ8wE2hbkXA+WyZ83fhQQn5DDmwDiDo6AwN/fhaH8oqZ0jRjMrO2iaMhDi6P1HRx6AZwyMinY1g==}
     peerDependencies:
@@ -2109,6 +2134,19 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.10':
     resolution: {integrity: sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==}
+    peerDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3
@@ -2175,6 +2213,19 @@ packages:
       react: 19.2.3
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-toggle-group@1.1.10':
@@ -2473,17 +2524,11 @@ packages:
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
 
-  '@shikijs/core@3.2.2':
-    resolution: {integrity: sha512-yvlSKVMLjddAGBa2Yu+vUZxuu3sClOWW1AG+UtJkvejYuGM5BVL35s6Ijiwb75O9QdEx6IkMxinHZSi8ZyrBaA==}
-
   '@shikijs/core@3.7.0':
     resolution: {integrity: sha512-yilc0S9HvTPyahHpcum8eonYrQtmGTU0lbtwxhA6jHv4Bm1cAdlPFRCJX4AHebkCm75aKTjjRAW+DezqD1b/cg==}
 
   '@shikijs/engine-javascript@1.29.2':
     resolution: {integrity: sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==}
-
-  '@shikijs/engine-javascript@3.2.2':
-    resolution: {integrity: sha512-tlDKfhWpF4jKLUyVAnmL+ggIC+0VyteNsUpBzh1iwWLZu4i+PelIRr0TNur6pRRo5UZIv3ss/PLMuwahg9S2hg==}
 
   '@shikijs/engine-javascript@3.7.0':
     resolution: {integrity: sha512-0t17s03Cbv+ZcUvv+y33GtX75WBLQELgNdVghnsdhTgU3hVcWcMsoP6Lb0nDTl95ZJfbP1mVMO0p3byVh3uuzA==}
@@ -2491,17 +2536,11 @@ packages:
   '@shikijs/engine-oniguruma@1.29.2':
     resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
 
-  '@shikijs/engine-oniguruma@3.2.2':
-    resolution: {integrity: sha512-vyXRnWVCSvokwbaUD/8uPn6Gqsf5Hv7XwcW4AgiU4Z2qwy19sdr6VGzMdheKKN58tJOOe5MIKiNb901bgcUXYQ==}
-
   '@shikijs/engine-oniguruma@3.7.0':
     resolution: {integrity: sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==}
 
   '@shikijs/langs@1.29.2':
     resolution: {integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==}
-
-  '@shikijs/langs@3.2.2':
-    resolution: {integrity: sha512-NY0Urg2dV9ETt3JIOWoMPuoDNwte3geLZ4M1nrPHbkDS8dWMpKcEwlqiEIGqtwZNmt5gKyWpR26ln2Bg2ecPgw==}
 
   '@shikijs/langs@3.7.0':
     resolution: {integrity: sha512-1zYtdfXLr9xDKLTGy5kb7O0zDQsxXiIsw1iIBcNOO8Yi5/Y1qDbJ+0VsFoqTlzdmneO8Ij35g7QKF8kcLyznCQ==}
@@ -2509,17 +2548,11 @@ packages:
   '@shikijs/themes@1.29.2':
     resolution: {integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==}
 
-  '@shikijs/themes@3.2.2':
-    resolution: {integrity: sha512-Zuq4lgAxVKkb0FFdhHSdDkALuRpsj1so1JdihjKNQfgM78EHxV2JhO10qPsMrm01FkE3mDRTdF68wfmsqjt6HA==}
-
   '@shikijs/themes@3.7.0':
     resolution: {integrity: sha512-VJx8497iZPy5zLiiCTSIaOChIcKQwR0FebwE9S3rcN0+J/GTWwQ1v/bqhTbpbY3zybPKeO8wdammqkpXc4NVjQ==}
 
   '@shikijs/types@1.29.2':
     resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
-
-  '@shikijs/types@3.2.2':
-    resolution: {integrity: sha512-a5TiHk7EH5Lso8sHcLHbVNNhWKP0Wi3yVnXnu73g86n3WoDgEra7n3KszyeCGuyoagspQ2fzvy4cpSc8pKhb0A==}
 
   '@shikijs/types@3.7.0':
     resolution: {integrity: sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==}
@@ -5036,17 +5069,11 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  oniguruma-parser@0.11.1:
-    resolution: {integrity: sha512-fX6SirDOsTUNqSUOnL3fDtD3R7PCXNWGA3WWPvv9egEfTWkNXzRLO/9CC1WkDusP6HyWRZig06kHeYPcw3mlqQ==}
-
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
   oniguruma-to-es@2.3.0:
     resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
-
-  oniguruma-to-es@4.2.0:
-    resolution: {integrity: sha512-MDPs6KSOLS0tKQ7joqg44dRIRZUyotfTy0r+7oEEs6VwWWP0+E2PPDYWMFN0aqOjRyWHBYq7RfKw9GQk2S2z5g==}
 
   oniguruma-to-es@4.3.3:
     resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
@@ -5651,9 +5678,6 @@ packages:
 
   shiki@1.29.2:
     resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
-
-  shiki@3.2.2:
-    resolution: {integrity: sha512-0qWBkM2t/0NXPRcVgtLhtHv6Ak3Q5yI4K/ggMqcgLRKm4+pCs3namgZlhlat/7u2CuqNtlShNs9lENOG6n7UaQ==}
 
   shiki@3.7.0:
     resolution: {integrity: sha512-ZcI4UT9n6N2pDuM2n3Jbk0sR4Swzq43nLPgS/4h0E3B/NrFn2HKElrDtceSf8Zx/OWYOo7G1SAtBLypCp+YXqg==}
@@ -7395,6 +7419,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
   '@radix-ui/react-arrow@1.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -7730,6 +7756,16 @@ snapshots:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-primitive@2.0.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-slot': 1.2.0(@types/react@19.2.8)(react@19.2.3)
@@ -7760,6 +7796,23 @@ snapshots:
   '@radix-ui/react-roving-focus@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
@@ -7842,6 +7895,22 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.8
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
   '@radix-ui/react-toggle-group@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -8068,13 +8137,6 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/core@3.2.2':
-    dependencies:
-      '@shikijs/types': 3.2.2
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-      hast-util-to-html: 9.0.5
-
   '@shikijs/core@3.7.0':
     dependencies:
       '@shikijs/types': 3.7.0
@@ -8088,12 +8150,6 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 2.3.0
 
-  '@shikijs/engine-javascript@3.2.2':
-    dependencies:
-      '@shikijs/types': 3.2.2
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.2.0
-
   '@shikijs/engine-javascript@3.7.0':
     dependencies:
       '@shikijs/types': 3.7.0
@@ -8105,11 +8161,6 @@ snapshots:
       '@shikijs/types': 1.29.2
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/engine-oniguruma@3.2.2':
-    dependencies:
-      '@shikijs/types': 3.2.2
-      '@shikijs/vscode-textmate': 10.0.2
-
   '@shikijs/engine-oniguruma@3.7.0':
     dependencies:
       '@shikijs/types': 3.7.0
@@ -8119,10 +8170,6 @@ snapshots:
     dependencies:
       '@shikijs/types': 1.29.2
 
-  '@shikijs/langs@3.2.2':
-    dependencies:
-      '@shikijs/types': 3.2.2
-
   '@shikijs/langs@3.7.0':
     dependencies:
       '@shikijs/types': 3.7.0
@@ -8131,20 +8178,11 @@ snapshots:
     dependencies:
       '@shikijs/types': 1.29.2
 
-  '@shikijs/themes@3.2.2':
-    dependencies:
-      '@shikijs/types': 3.2.2
-
   '@shikijs/themes@3.7.0':
     dependencies:
       '@shikijs/types': 3.7.0
 
   '@shikijs/types@1.29.2':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
-  '@shikijs/types@3.2.2':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -8944,7 +8982,7 @@ snapshots:
       prompts: 2.4.2
       rehype: 13.0.2
       semver: 7.7.1
-      shiki: 3.2.2
+      shiki: 3.7.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.12
       tsconfck: 3.1.5(typescript@5.9.3)
@@ -11247,8 +11285,6 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-parser@0.11.1: {}
-
   oniguruma-parser@0.12.1: {}
 
   oniguruma-to-es@2.3.0:
@@ -11256,13 +11292,6 @@ snapshots:
       emoji-regex-xs: 1.0.0
       regex: 5.1.1
       regex-recursion: 5.1.1
-
-  oniguruma-to-es@4.2.0:
-    dependencies:
-      emoji-regex-xs: 1.0.0
-      oniguruma-parser: 0.11.1
-      regex: 6.0.1
-      regex-recursion: 6.0.2
 
   oniguruma-to-es@4.3.3:
     dependencies:
@@ -12054,17 +12083,6 @@ snapshots:
       '@shikijs/langs': 1.29.2
       '@shikijs/themes': 1.29.2
       '@shikijs/types': 1.29.2
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
-  shiki@3.2.2:
-    dependencies:
-      '@shikijs/core': 3.2.2
-      '@shikijs/engine-javascript': 3.2.2
-      '@shikijs/engine-oniguruma': 3.2.2
-      '@shikijs/langs': 3.2.2
-      '@shikijs/themes': 3.2.2
-      '@shikijs/types': 3.2.2
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 


### PR DESCRIPTION
## Component / Package Name:

`apps/web` - Blocks System

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

Adds a new **Blocks** system to the jsx-email documentation site - a collection of ready-to-use email blocks that users can copy and paste into their templates.

**New Features:**

- `/blocks` index page with categorized block listings
- Live preview system with `BlockPreview` component for viewing blocks at different sizes
- `PatternCard` component for block navigation

**Block Categories Added:**

| Category | Blocks | Count |
|----------|--------|-------|
| Layout | Gallery, Articles | 6 blocks |
| User Feedback | Surveys, Feedback, Testimonials | 7 blocks |
| Marketing | Marketing, Ecommerce Pricing | 5 blocks |
| General | Avatars | 4 blocks |

**22 total blocks** across 8 block types:

- **Avatars** - Avatar stacks, groups, and layouts
- **Articles** - Article cards and list layouts  
- **Ecommerce Pricing** - Pricing tables and product cards
- **Feedback** - Emoji reactions, rating systems
- **Gallery** - Image grid layouts
- **Marketing** - Hero sections, CTAs, promotional blocks
- **Surveys** - NPS scores, rating scales, feedback forms
- **Testimonials** - Quote blocks, customer reviews
