### PR TITLE
feat(plugin-url)!: initial release

### DIFF
--- a/apps/web/src/content/docs/_meta.json
+++ b/apps/web/src/content/docs/_meta.json
@@ -45,5 +45,6 @@
   "Plugins",
   ["plugins/inline", "Inline CSS Plugin"],
   ["plugins/minify", "Minify Plugin"],
-  ["plugins/pretty", "Pretty Plugin"]
+  ["plugins/pretty", "Pretty Plugin"],
+  ["plugins/url", "URL Plugin"]
 ]

--- a/apps/web/src/content/docs/plugins/_meta.json
+++ b/apps/web/src/content/docs/plugins/_meta.json
@@ -10,5 +10,9 @@
   [
     "pretty",
     "Pretty Plugin"
+  ],
+  [
+    "url",
+    "URL Plugin"
   ]
 ]

--- a/apps/web/src/content/docs/plugins/url.mdx
+++ b/apps/web/src/content/docs/plugins/url.mdx
@@ -1,0 +1,149 @@
+---
+title: 'URL Plugin'
+description: 'The URL Plugin'
+---
+
+## URL Plugin
+
+The `@jsx-email/plugin-url` package provides a plugin for modifying URLs in rendered email HTML. The initial `append` option appends URL parameters to matching URL attributes.
+
+This plugin is not loaded automatically by `jsx-email`. Add it to your configuration's `plugins` array.
+
+Browse this plugin's [source code](https://github.com/shellscape/jsx-email/blob/main/packages/plugin-url)
+
+## Usage
+
+```js
+import { defineConfig } from 'jsx-email/config';
+import { urlPlugin } from '@jsx-email/plugin-url';
+
+export const config = defineConfig({
+  plugins: [
+    urlPlugin({
+      append: {
+        parameters: {
+          utm_campaign: 'Campaign Name',
+          utm_medium: 'email',
+          utm_source: 'jsx-email'
+        }
+      }
+    })
+  ]
+});
+```
+
+Given this HTML:
+
+```html
+<a href="https://example.com">Test</a>
+```
+
+The output will include appended URL parameters:
+
+```html
+<a href="https://example.com?utm_campaign=Campaign Name&utm_medium=email&utm_source=jsx-email"
+  >Test</a
+>
+```
+
+## Options
+
+### append
+
+Type: `Object`
+
+Appends URL parameters to matching URL attributes.
+
+### attributes
+
+Type: `String[]`
+Default: `['src', 'href', 'poster', 'srcset', 'background']`
+
+Array of attributes to process for matching tags.
+
+```js
+urlPlugin({
+  append: {
+    attributes: ['data-href', 'src'],
+    parameters: {
+      foo: 'bar'
+    },
+    tags: ['a', 'img']
+  }
+});
+```
+
+### parameters
+
+Type: `Object`
+
+Object containing the URL parameters to append.
+
+```js
+urlPlugin({
+  append: {
+    parameters: {
+      custom_parameter: 'foo',
+      utm_campaign: 'Campaign Name',
+      utm_medium: 'email',
+      utm_source: 'jsx-email'
+    }
+  }
+});
+```
+
+### qs
+
+Type: `Object`
+Default: `{ encode: false }`
+
+Options for serializing appended URL parameters.
+
+```js
+urlPlugin({
+  append: {
+    parameters: {
+      foo: '@Bar@'
+    },
+    qs: {
+      encode: true
+    }
+  }
+});
+```
+
+### strict
+
+Type: `Boolean`
+Default: `true`
+
+When enabled, URL parameters are appended only to valid URLs. Disable strict mode to append URL parameters to any string.
+
+```js
+urlPlugin({
+  append: {
+    parameters: {
+      foo: 'bar'
+    },
+    strict: false
+  }
+});
+```
+
+### tags
+
+Type: `String[]`
+Default: `['a']`
+
+Array of tag names or CSS selectors to process.
+
+```js
+urlPlugin({
+  append: {
+    parameters: {
+      foo: 'bar'
+    },
+    tags: ['a[href*="example.com"]']
+  }
+});
+```

--- a/moon.yml
+++ b/moon.yml
@@ -15,6 +15,7 @@ tasks:
       - plugin-inline:build
       - plugin-minify:build
       - plugin-pretty:build
+      - plugin-url:build
       - create-mail:build
 
   build.all:

--- a/packages/plugin-url/CHANGELOG.md
+++ b/packages/plugin-url/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @jsx-email/plugin-url ChangeLog
+
+## v2.0.0
+
+_2026-05-11_
+
+### Features
+
+- plugin-url: add URL parameter appending plugin

--- a/packages/plugin-url/README.md
+++ b/packages/plugin-url/README.md
@@ -1,0 +1,22 @@
+[npm]: https://img.shields.io/npm/v/@jsx-email/plugin-url
+[npm-url]: https://www.npmjs.com/package/@jsx-email/plugin-url
+
+[![npm][npm]][npm-url]
+[![Join our Discord](https://img.shields.io/badge/join_our-Discord-5a64ea)](https://discord.gg/FywZN57mTg)
+[![libera manifesto](https://img.shields.io/badge/libera-manifesto-lightgrey.svg)](https://liberamanifesto.com)
+
+<div align="center">
+	<img src="https://raw.githubusercontent.com/shellscape/jsx-email/main/assets/npm-header.svg" alt="JSX email"/><br/><br/>
+</div>
+
+# JSX&thinsp;email URL Plugin
+
+`@jsx-email/plugin-url` is a JSX email plugin that modifies URLs in rendered email HTML.
+
+The initial `append` option appends URL parameters to matching URL attributes. This plugin is not loaded automatically by `jsx-email`; add it to your configuration's `plugins` array.
+
+Please see the [documentation for this plugin](https://jsx.email/docs/plugins/url) for more information.
+
+## License
+
+[MIT License](./LICENSE.md)

--- a/packages/plugin-url/moon.yml
+++ b/packages/plugin-url/moon.yml
@@ -1,0 +1,17 @@
+# https://moonrepo.dev/docs/config/tasks
+$schema: 'https://moonrepo.dev/schemas/project.json'
+
+tasks:
+  test:
+    command: vitest --config ../../shared/vitest.config.ts
+    deps:
+      - ~:build
+    inputs:
+      - src
+      - test
+      - package.json
+    env:
+      FORCE_COLOR: '1'
+    options:
+      cache: false
+      outputStyle: 'stream'

--- a/packages/plugin-url/package.json
+++ b/packages/plugin-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsx-email/plugin-url",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugin-url/package.json
+++ b/packages/plugin-url/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@jsx-email/plugin-url",
+  "version": "2.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "A URL plugin for jsx-email",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shellscape/jsx-email.git",
+    "directory": "packages/plugin-url"
+  },
+  "author": "Andrew Powell <andrew@shellscape.org>",
+  "homepage": "https://jsx.email/",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "files": [
+    "dist/**"
+  ],
+  "keywords": [
+    "email",
+    "html",
+    "jsx",
+    "jsx-email",
+    "plugin",
+    "preset",
+    "react",
+    "rehype",
+    "rehype-plugin",
+    "unified",
+    "url"
+  ],
+  "peerDependencies": {
+    "jsx-email": "^3.0.0"
+  },
+  "dependencies": {
+    "hast-util-select": "^6.0.4",
+    "unist-util-visit": "catalog:"
+  },
+  "devDependencies": {
+    "hast": "catalog:",
+    "jsx-email": "workspace:^",
+    "rehype": "^13.0.1",
+    "rehype-stringify": "^10.0.0",
+    "unified": "catalog:"
+  },
+  "types": "./dist/index.d.ts",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/shellscape"
+  },
+  "sideEffects": false
+}

--- a/packages/plugin-url/src/index.ts
+++ b/packages/plugin-url/src/index.ts
@@ -1,0 +1,167 @@
+import type { Element, Root } from 'hast';
+import { selectAll } from 'hast-util-select';
+import { type JsxEmailPlugin, pluginSymbol } from 'jsx-email';
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+
+export interface AppendOptions {
+  attributes?: string[];
+  parameters: Record<string, boolean | null | number | string | undefined>;
+  qs?: QueryStringOptions;
+  strict?: boolean;
+  tags?: string[];
+}
+
+export interface QueryStringOptions {
+  encode?: boolean;
+}
+
+export interface UrlPluginOptions {
+  /**
+   * Appends URL parameters to matching URL attributes in the rendered email HTML.
+   */
+  append?: AppendOptions;
+}
+
+const defaultAppendOptions = {
+  attributes: ['src', 'href', 'poster', 'srcset', 'background'],
+  qs: {
+    encode: false
+  },
+  strict: true,
+  tags: ['a']
+} satisfies Omit<Required<AppendOptions>, 'parameters'>;
+
+const appendParameters = (
+  value: string,
+  parameters: AppendOptions['parameters'],
+  qs: QueryStringOptions
+) => {
+  const entries = Object.entries(parameters).filter(([, entryValue]) => entryValue !== undefined);
+
+  if (!entries.length) return value;
+
+  const hashIndex = value.indexOf('#');
+  const path = hashIndex === -1 ? value : value.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? '' : value.slice(hashIndex);
+  const separator = path.includes('?') ? (/[?&]$/.test(path) ? '' : '&') : '?';
+  const query = entries
+    .map(([key, entryValue]) => {
+      const normalizedValue = entryValue === null ? '' : String(entryValue);
+      if (qs.encode) return `${encodeURIComponent(key)}=${encodeURIComponent(normalizedValue)}`;
+
+      return `${key}=${normalizedValue}`;
+    })
+    .join('&');
+
+  return `${path}${separator}${query}${hash}`;
+};
+
+const isStrictUrl = (value: string) => {
+  try {
+    const UrlConstructor = (
+      globalThis as unknown as {
+        URL: new (url: string) => { protocol: string };
+      }
+    ).URL;
+
+    return Boolean(new UrlConstructor(value).protocol);
+  } catch {
+    return false;
+  }
+};
+
+const transformSrcset = (
+  value: string,
+  parameters: AppendOptions['parameters'],
+  qs: QueryStringOptions,
+  strict: boolean
+) =>
+  value
+    .split(',')
+    .map((candidate) => {
+      const trimmed = candidate.trim();
+      const [url = '', ...descriptors] = trimmed.split(/\s+/);
+
+      if (!url || (strict && !isStrictUrl(url))) return candidate;
+
+      return [appendParameters(url, parameters, qs), ...descriptors].join(' ');
+    })
+    .join(', ');
+
+const transformValue = (
+  attribute: string,
+  value: string,
+  parameters: AppendOptions['parameters'],
+  qs: QueryStringOptions,
+  strict: boolean
+) => {
+  if (attribute === 'srcset') return transformSrcset(value, parameters, qs, strict);
+  if (strict && !isStrictUrl(value)) return value;
+
+  return appendParameters(value, parameters, qs);
+};
+
+const getSelectedElements = (tree: Root, tags: string[]) => {
+  const selected = new Set<Element>();
+
+  for (const tag of tags) {
+    for (const element of selectAll(tag, tree)) selected.add(element);
+  }
+
+  return selected;
+};
+
+const getPropertyKeys = (attribute: string) => {
+  const propertyKeys = new Set([attribute]);
+
+  propertyKeys.add(attribute.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase()));
+  if (attribute === 'srcset') propertyKeys.add('srcSet');
+
+  return propertyKeys;
+};
+
+export const urlPlugin = (options: UrlPluginOptions = {}): JsxEmailPlugin => ({
+  name: 'root/url',
+  process: async () => {
+    return function appendUrlParametersPlugin() {
+      return function appendUrlParameters(tree: Root) {
+        if (!tree || !options.append) return null;
+
+        const appendOptions = {
+          ...defaultAppendOptions,
+          ...options.append,
+          qs: {
+            ...defaultAppendOptions.qs,
+            ...options.append.qs
+          }
+        };
+        const selectedElements = getSelectedElements(tree, appendOptions.tags);
+
+        return visit(tree, 'element', (node) => {
+          if (!selectedElements.has(node)) return;
+
+          for (const attribute of appendOptions.attributes) {
+            const propertyKey = Array.from(getPropertyKeys(attribute)).find(
+              (key) => typeof node.properties?.[key] === 'string'
+            );
+            const value = propertyKey ? node.properties?.[propertyKey] : null;
+
+            if (propertyKey && typeof value === 'string') {
+              node.properties[propertyKey] = transformValue(
+                attribute,
+                value,
+                appendOptions.parameters,
+                appendOptions.qs,
+                appendOptions.strict
+              );
+            }
+          }
+        });
+      };
+    } as unknown as Plugin;
+  },
+  symbol: pluginSymbol
+});
+
+export const plugin = urlPlugin();

--- a/packages/plugin-url/test/index.test.ts
+++ b/packages/plugin-url/test/index.test.ts
@@ -1,0 +1,173 @@
+import { rehype } from 'rehype';
+import stringify from 'rehype-stringify';
+import { describe, expect, it } from 'vitest';
+
+import { plugin, type UrlPluginOptions, urlPlugin } from '../src/index.js';
+
+const processHtml = async (html: string, options: UrlPluginOptions = urlPluginOptions) => {
+  const pluggable = await urlPlugin(options).process?.({ chalk: {} as any, log: {} });
+  const doc = await rehype()
+    .data('settings', { fragment: true })
+    .use(pluggable as any)
+    .use(stringify, {
+      allowDangerousCharacters: true,
+      allowDangerousHtml: true
+    })
+    .process(html);
+
+  return String(doc);
+};
+
+const urlPluginOptions = {
+  append: {
+    parameters: {
+      utm_source: 'jsx-email'
+    }
+  }
+};
+
+describe('@jsx-email/plugin-url', () => {
+  it('exports a valid jsx-email plugin', () => {
+    expect(plugin.name).toBe('root/url');
+    expect(plugin.symbol).toBe(Symbol.for('jsx-email/plugin'));
+  });
+
+  it('does nothing when append is omitted', async () => {
+    await expect(processHtml('<a href="https://example.com">Test</a>', {})).resolves.toBe(
+      '<a href="https://example.com">Test</a>'
+    );
+  });
+
+  it('appends URL parameters to anchor href attributes by default', async () => {
+    await expect(processHtml('<a href="https://example.com">Test</a>')).resolves.toBe(
+      '<a href="https://example.com?utm_source=jsx-email">Test</a>'
+    );
+  });
+
+  it('adds an ampersand when the URL already has query parameters', async () => {
+    await expect(processHtml('<a href="https://example.com?foo=bar">Test</a>')).resolves.toBe(
+      '<a href="https://example.com?foo=bar&#x26;utm_source=jsx-email">Test</a>'
+    );
+  });
+
+  it('keeps fragments after appended URL parameters', async () => {
+    await expect(processHtml('<a href="https://example.com#section">Test</a>')).resolves.toBe(
+      '<a href="https://example.com?utm_source=jsx-email#section">Test</a>'
+    );
+  });
+
+  it('keeps existing query parameters and fragments in order', async () => {
+    await expect(
+      processHtml('<a href="https://example.com?foo=bar#section">Test</a>')
+    ).resolves.toBe(
+      '<a href="https://example.com?foo=bar&#x26;utm_source=jsx-email#section">Test</a>'
+    );
+  });
+
+  it('supports custom attributes', async () => {
+    await expect(
+      processHtml('<a data-href="https://example.com" href="https://foo.bar">Test</a>', {
+        append: {
+          attributes: ['data-href'],
+          parameters: {
+            foo: 'bar'
+          }
+        }
+      })
+    ).resolves.toBe('<a data-href="https://example.com?foo=bar" href="https://foo.bar">Test</a>');
+  });
+
+  it('supports custom tags', async () => {
+    await expect(
+      processHtml('<a href="https://example.com">Test</a><img src="https://example.com/img.png">', {
+        append: {
+          parameters: {
+            foo: 'bar'
+          },
+          tags: ['img']
+        }
+      })
+    ).resolves.toBe(
+      '<a href="https://example.com">Test</a><img src="https://example.com/img.png?foo=bar">'
+    );
+  });
+
+  it('supports selector-based tags', async () => {
+    await expect(
+      processHtml('<a href="https://example.com">One</a><a href="https://other.com">Two</a>', {
+        append: {
+          parameters: {
+            foo: 'bar'
+          },
+          tags: ['a[href*="example.com"]']
+        }
+      })
+    ).resolves.toBe(
+      '<a href="https://example.com?foo=bar">One</a><a href="https://other.com">Two</a>'
+    );
+  });
+
+  it('does not append URL parameters to invalid URLs in strict mode', async () => {
+    await expect(processHtml('<a href="example.com">Test</a>')).resolves.toBe(
+      '<a href="example.com">Test</a>'
+    );
+  });
+
+  it('appends URL parameters to any string when strict is false', async () => {
+    await expect(
+      processHtml('<a href="example.com">Test</a>', {
+        append: {
+          parameters: {
+            foo: 'bar'
+          },
+          strict: false
+        }
+      })
+    ).resolves.toBe('<a href="example.com?foo=bar">Test</a>');
+  });
+
+  it('encodes URL parameters when qs encode is true', async () => {
+    await expect(
+      processHtml('<a href="https://example.com">Test</a>', {
+        append: {
+          parameters: {
+            foo: '@Bar@'
+          },
+          qs: {
+            encode: true
+          }
+        }
+      })
+    ).resolves.toBe('<a href="https://example.com?foo=%40Bar%40">Test</a>');
+  });
+
+  it('does not encode URL parameters by default', async () => {
+    await expect(
+      processHtml('<a href="https://example.com">Test</a>', {
+        append: {
+          parameters: {
+            foo: '@Bar@'
+          }
+        }
+      })
+    ).resolves.toBe('<a href="https://example.com?foo=@Bar@">Test</a>');
+  });
+
+  it('appends URL parameters to srcset candidates', async () => {
+    await expect(
+      processHtml(
+        '<img srcset="https://example.com/small.png 1x, https://example.com/large.png 2x">',
+        {
+          append: {
+            parameters: {
+              foo: 'bar'
+            },
+            tags: ['img']
+          }
+        }
+      )
+    ).resolves.toBe(
+      '<img srcset="https://example.com/small.png?foo=bar 1x, https://example.com/large.png?foo=bar 2x">'
+    );
+  });
+});

--- a/packages/plugin-url/tsconfig.json
+++ b/packages/plugin-url/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "extends": "../../shared/tsconfig.base.json",
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,6 +750,31 @@ importers:
         specifier: workspace:^
         version: link:../jsx-email
 
+  packages/plugin-url:
+    dependencies:
+      hast-util-select:
+        specifier: ^6.0.4
+        version: 6.0.4
+      unist-util-visit:
+        specifier: 'catalog:'
+        version: 5.1.0
+    devDependencies:
+      hast:
+        specifier: 'catalog:'
+        version: 1.0.0
+      jsx-email:
+        specifier: workspace:^
+        version: link:../jsx-email
+      rehype:
+        specifier: ^13.0.1
+        version: 13.0.2
+      rehype-stringify:
+        specifier: ^10.0.0
+        version: 10.0.1
+      unified:
+        specifier: 'catalog:'
+        version: 11.0.5
+
   test/cli:
     dependencies:
       create-mail:


### PR DESCRIPTION
## Component / Package Name:

  @jsx-email/plugin-url

  This PR contains:

  - [ ] bugfix
  - [x] feature
  - [ ] refactor
  - [x] documentation
  - [ ] other

  Are tests included?

  - [x] yes (_bugfixes and features will not be merged without tests_)
  - [ ] no

  Breaking Changes?

  - [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
  - [x] no

  List any relevant issue numbers:

  N/A

  ### Description

  Adds `@jsx-email/plugin-url`, a new plugin for modifying URLs in rendered email HTML.

  The initial feature is `append`, which appends URL parameters to matching URL attributes. It supports Maizzle-style
  behavior without adding any default `jsx-email` render integration. Users opt in by adding `urlPlugin(...)` to their
  config `plugins` array.

  Included behavior:
  - Defaults to processing `a` tags.
  - Defaults to URL attributes `src`, `href`, `poster`, `srcset`, and `background`.
  - Defaults to strict URL matching.
  - Defaults to unencoded query parameter serialization.
  - Correctly inserts `?` for URLs without query strings and `&` for URLs with existing query strings.
  - Preserves URL fragments.
  - Supports custom tags, selector-based tags, custom attributes, `srcset`, strict mode, and query string encoding.

  This also adds plugin documentation and sidebar entries for the URL Plugin.

